### PR TITLE
get_categorical_cardinalities and get_numeric_cardinalities now use column_types

### DIFF
--- a/metalearn/metafeatures/common_operations.py
+++ b/metalearn/metafeatures/common_operations.py
@@ -26,5 +26,10 @@ def profile_distribution(data):
 def get_numeric_features(dataframe, column_types):
     return [feature for feature in dataframe.columns if column_types[feature] == "NUMERIC"]
 
+def get_categorical_features(dataframe, column_types):
+    return [feature for feature in dataframe.columns if column_types[feature] == "CATEGORICAL"]
+
 def dtype_is_numeric(dtype):
     return "int" in str(dtype) or "float" in str(dtype)
+
+# from metalearn.metafeatures import metafeatures

--- a/metalearn/metafeatures/common_operations.py
+++ b/metalearn/metafeatures/common_operations.py
@@ -31,5 +31,3 @@ def get_categorical_features(dataframe, column_types):
 
 def dtype_is_numeric(dtype):
     return "int" in str(dtype) or "float" in str(dtype)
-
-# from metalearn.metafeatures import metafeatures

--- a/metalearn/metafeatures/metafeatures.json
+++ b/metalearn/metafeatures/metafeatures.json
@@ -63,7 +63,7 @@
 			"returns": ["XSample","YSample"]
 		},
 		"self._get_preprocessed_data": {
-			"parameters": ["XSample","XSampledColumns", "Seed"],
+			"parameters": ["XSample","XSampledColumns", "ColumnTypes", "Seed"],
 			"seed_offset": 2,
 			"returns": ["XPreprocessed"]
 		},

--- a/metalearn/metafeatures/metafeatures.json
+++ b/metalearn/metafeatures/metafeatures.json
@@ -96,11 +96,11 @@
 			"returns": ["MeanClassProbability","StdevClassProbability","MinClassProbability","MaxClassProbability","MinorityClassSize","MajorityClassSize"]
 		},
 		"get_categorical_cardinalities": {
-			"parameters": ["X"],
+			"parameters": ["X", "ColumnTypes"],
 			"returns": ["MeanCardinalityOfCategoricalFeatures","StdevCardinalityOfCategoricalFeatures","MinCardinalityOfCategoricalFeatures","MaxCardinalityOfCategoricalFeatures"]
 		},
 		"get_numeric_cardinalities": {
-			"parameters": ["X"],
+			"parameters": ["X", "ColumnTypes"],
 			"returns": ["MeanCardinalityOfNumericFeatures","StdevCardinalityOfNumericFeatures","MinCardinalityOfNumericFeatures","MaxCardinalityOfNumericFeatures"]
 		},
 		"get_numeric_means": {

--- a/metalearn/metafeatures/metafeatures.json
+++ b/metalearn/metafeatures/metafeatures.json
@@ -1,634 +1,634 @@
 {
-	"resources": {
-		"XRaw": {
-			"function": ""
-		},
-		"X": {
-			"function": ""
-		},
-		"Y": {
-			"function": ""
-		},
-		"ColumnTypes": {
-			"function": ""
-		},
-		"SampleRowsFlag": {
-			"function": ""
-		},
-		"SampleColumnsFlag": {
-			"function": ""
-		},
-		"Seed": {
-			"function": "self._get_random_seed"
-		},
-		"XSampledColumns": {
-			"function": "self._get_sample_of_columns"
-		},
-		"XSample": {
-			"function": "self._get_sample_of_rows"
-		},
-		"YSample": {
-			"function": "self._get_sample_of_rows"
-		},
-		"XPreprocessed": {
-			"function": "self._get_preprocessed_data"
-		},
-		"NoNaNCategoricalFeaturesAndClass": {
-			"function": "self._get_categorical_features_and_class_with_no_missing_values"
-		},
-		"NoNaNNumericFeaturesAndClass": {
-			"function": "self._get_numeric_features_and_class_with_no_missing_values"
-		},
-		"NoNaNBinnedNumericFeaturesAndClass": {
-			"function": "self._get_binned_numeric_features_and_class_with_no_missing_values"
-		}
-	},
-	"functions": {
-		"": {
-			"parameters": [],
-			"returns": []
-		},
-		"self._get_random_seed":{
-			"parameters": [],
-			"returns": ["Seed"]
-		},
-		"self._get_sample_of_columns": {
-			"parameters": ["X","SampleColumnsFlag","Seed"],
-			"seed_offset": 0,
-			"returns": ["XSampledColumns"]
-		},
-		"self._get_sample_of_rows": {
-			"parameters": ["XSampledColumns","Y","SampleRowsFlag", "Seed"],
-			"seed_offset": 1,
-			"returns": ["XSample","YSample"]
-		},
-		"self._get_preprocessed_data": {
-			"parameters": ["XSample","XSampledColumns", "ColumnTypes", "Seed"],
-			"seed_offset": 2,
-			"returns": ["XPreprocessed"]
-		},
-		"self._get_categorical_features_and_class_with_no_missing_values": {
-			"parameters": ["XSample","YSample", "ColumnTypes"],
-			"returns": ["NoNaNCategoricalFeaturesAndClass"]
-		},
-		"self._get_numeric_features_and_class_with_no_missing_values": {
-			"parameters": ["XSample","YSample", "ColumnTypes"],
-			"returns": ["NoNaNNumericFeaturesAndClass"]
-		},
-		"self._get_binned_numeric_features_and_class_with_no_missing_values": {
-			"parameters": ["NoNaNNumericFeaturesAndClass"],
-			"returns": ["NoNaNBinnedNumericFeaturesAndClass"]
-		},
-		"get_dataset_stats": {
-			"parameters": ["XRaw","Y", "ColumnTypes"],
-			"returns": ["NumberOfInstances","NumberOfFeatures","NumberOfClasses","NumberOfNumericFeatures","NumberOfCategoricalFeatures","RatioOfNumericFeatures","RatioOfCategoricalFeatures"]
-		},
-		"get_dimensionality": {
-			"parameters": ["NumberOfFeatures","NumberOfInstances"],
-			"returns": ["Dimensionality"]
-		},
-		"get_missing_values": {
-			"parameters": ["XRaw"],
-			"returns": ["NumberOfMissingValues","RatioOfMissingValues","NumberOfInstancesWithMissingValues","RatioOfInstancesWithMissingValues"]
-		},
-		"get_class_stats": {
-			"parameters": ["Y"],
-			"returns": ["MeanClassProbability","StdevClassProbability","MinClassProbability","MaxClassProbability","MinorityClassSize","MajorityClassSize"]
-		},
-		"get_categorical_cardinalities": {
-			"parameters": ["X", "ColumnTypes"],
-			"returns": ["MeanCardinalityOfCategoricalFeatures","StdevCardinalityOfCategoricalFeatures","MinCardinalityOfCategoricalFeatures","MaxCardinalityOfCategoricalFeatures"]
-		},
-		"get_numeric_cardinalities": {
-			"parameters": ["X", "ColumnTypes"],
-			"returns": ["MeanCardinalityOfNumericFeatures","StdevCardinalityOfNumericFeatures","MinCardinalityOfNumericFeatures","MaxCardinalityOfNumericFeatures"]
-		},
-		"get_numeric_means": {
-			"parameters": ["NoNaNNumericFeaturesAndClass"],
-			"returns": ["MeanMeansOfNumericFeatures","StdevMeansOfNumericFeatures","MinMeansOfNumericFeatures","Quartile1MeansOfNumericFeatures","Quartile2MeansOfNumericFeatures","Quartile3MeansOfNumericFeatures","MaxMeansOfNumericFeatures"]
-		},
-		"get_numeric_stdev": {
-			"parameters": ["NoNaNNumericFeaturesAndClass"],
-			"returns": ["MeanStdDevOfNumericFeatures","StdevStdDevOfNumericFeatures","MinStdDevOfNumericFeatures","Quartile1StdDevOfNumericFeatures","Quartile2StdDevOfNumericFeatures","Quartile3StdDevOfNumericFeatures","MaxStdDevOfNumericFeatures"]
-		},
-		"get_numeric_skewness": {
-			"parameters": ["NoNaNNumericFeaturesAndClass"],
-			"returns": ["MeanSkewnessOfNumericFeatures","StdevSkewnessOfNumericFeatures","MinSkewnessOfNumericFeatures","Quartile1SkewnessOfNumericFeatures","Quartile2SkewnessOfNumericFeatures","Quartile3SkewnessOfNumericFeatures","MaxSkewnessOfNumericFeatures"]
-		},
-		"get_numeric_kurtosis": {
-			"parameters": ["NoNaNNumericFeaturesAndClass"],
-			"returns": ["MeanKurtosisOfNumericFeatures","StdevKurtosisOfNumericFeatures","MinKurtosisOfNumericFeatures","Quartile1KurtosisOfNumericFeatures","Quartile2KurtosisOfNumericFeatures","Quartile3KurtosisOfNumericFeatures","MaxKurtosisOfNumericFeatures"]
-		},
-		"get_pca": {
-			"parameters": ["XPreprocessed"],
-			"returns": ["PredPCA1","PredPCA2","PredPCA3","PredEigen1","PredEigen2","PredEigen3","PredDet"]
-		},
-		"get_correlations": {
-			"parameters": ["XSample", "ColumnTypes"],
-			"returns": ["MeanCanonicalCorrelation","StdevCanonicalCorrelation"]
-		},
-		"get_class_entropy": {
-			"parameters": ["YSample"],
-			"returns": ["ClassEntropy"]
-		},
-		"get_attribute_entropy": {
-			"parameters": [],
-			"returns": []
-		},
-		"get_joint_entropy": {
-			"parameters": [],
-			"returns": []
-		},
-		"get_mutual_information": {
-			"parameters": [],
-			"returns": []
-		},
-		"get_equivalent_number_features": {
-			"parameters": [],
-			"returns": []
-		},
-		"get_noise_signal_ratio": {
-			"parameters": [],
-			"returns": []
-		},
-		"get_naive_bayes": {
-			"parameters": ["XPreprocessed","YSample", "Seed"],
-			"seed_offset": 3,
-			"returns": ["NaiveBayesErrRate","NaiveBayesKappa"]
-		},
-		"get_knn_1": {
-			"parameters": ["XPreprocessed","YSample", "Seed"],
-			"seed_offset": 4,
-			"returns": ["kNN1NErrRate","kNN1NKappa"]
-		},
-		"get_decision_stump": {
-			"parameters": ["XPreprocessed","YSample","Seed"],
-			"seed_offset": 5,
-			"returns": ["DecisionStumpErrRate","DecisionStumpKappa"]
-		},
-		"get_random_tree": {
-			"parameters": [],
-			"seed_offset": null,
-			"returns": []
-		},
-		"get_lda": {
-			"parameters": ["XPreprocessed","YSample", "Seed"],
-			"seed_offset": 6,
-			"returns": ["LinearDiscriminantAnalysisErrRate","LinearDiscriminantAnalysisKappa"]
-		}
-	},
-	"metafeatures": {
-		"NumberOfInstances": {
-			"function": "get_dataset_stats"
-		},
-		"NumberOfFeatures": {
-			"function": "get_dataset_stats"
-		},
-		"NumberOfClasses": {
-			"function": "get_dataset_stats"
-		},
-		"NumberOfNumericFeatures": {
-			"function": "get_dataset_stats"
-		},
-		"NumberOfCategoricalFeatures": {
-			"function": "get_dataset_stats"
-		},
-		"RatioOfNumericFeatures": {
-			"function": "get_dataset_stats"
-		},
-		"RatioOfCategoricalFeatures": {
-			"function": "get_dataset_stats"
-		},
-		"Dimensionality": {
-			"function": "get_dimensionality"
-		},
-		"NumberOfMissingValues": {
-			"function": "get_missing_values"
-		},
-		"RatioOfMissingValues": {
-			"function": "get_missing_values"
-		},
-		"NumberOfInstancesWithMissingValues": {
-			"function": "get_missing_values"
-		},
-		"RatioOfInstancesWithMissingValues": {
-			"function": "get_missing_values"
-		},
-		"MeanClassProbability": {
-			"function": "get_class_stats"
-		},
-		"StdevClassProbability": {
-			"function": "get_class_stats"
-		},
-		"MinClassProbability": {
-			"function": "get_class_stats"
-		},
-		"MaxClassProbability": {
-			"function": "get_class_stats"
-		},
-		"MinorityClassSize": {
-			"function": "get_class_stats"
-		},
-		"MajorityClassSize": {
-			"function": "get_class_stats"
-		},
-		"MeanCardinalityOfCategoricalFeatures": {
-			"function": "get_categorical_cardinalities"
-		},
-		"StdevCardinalityOfCategoricalFeatures": {
-			"function": "get_categorical_cardinalities"
-		},
-		"MinCardinalityOfCategoricalFeatures": {
-			"function": "get_categorical_cardinalities"
-		},
-		"MaxCardinalityOfCategoricalFeatures": {
-			"function": "get_categorical_cardinalities"
-		},
-		"MeanCardinalityOfNumericFeatures": {
-			"function": "get_numeric_cardinalities"
-		},
-		"StdevCardinalityOfNumericFeatures": {
-			"function": "get_numeric_cardinalities"
-		},
-		"MinCardinalityOfNumericFeatures": {
-			"function": "get_numeric_cardinalities"
-		},
-		"MaxCardinalityOfNumericFeatures": {
-			"function": "get_numeric_cardinalities"
-		},
-		"MeanMeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"StdevMeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"MinMeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"MaxMeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"Quartile1MeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"Quartile2MeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"Quartile3MeansOfNumericFeatures": {
-			"function": "get_numeric_means"
-		},
-		"MeanStdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"StdevStdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"MinStdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"MaxStdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"Quartile1StdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"Quartile2StdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"Quartile3StdDevOfNumericFeatures": {
-			"function": "get_numeric_stdev"
-		},
-		"MeanSkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"StdevSkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"MinSkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"MaxSkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"Quartile1SkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"Quartile2SkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"Quartile3SkewnessOfNumericFeatures": {
-			"function": "get_numeric_skewness"
-		},
-		"MeanKurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"StdevKurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"MinKurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"MaxKurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"Quartile1KurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"Quartile2KurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"Quartile3KurtosisOfNumericFeatures": {
-			"function": "get_numeric_kurtosis"
-		},
-		"PredPCA1": {
-			"function": "get_pca"
-		},
-		"PredPCA2": {
-			"function": "get_pca"
-		},
-		"PredPCA3": {
-			"function": "get_pca"
-		},
-		"PredEigen1": {
-			"function": "get_pca"
-		},
-		"PredEigen2": {
-			"function": "get_pca"
-		},
-		"PredEigen3": {
-			"function": "get_pca"
-		},
-		"PredDet": {
-			"function": "get_pca"
-		},
-		"MeanCanonicalCorrelation": {
-			"function": "get_correlations"
-		},
-		"StdevCanonicalCorrelation": {
-			"function": "get_correlations"
-		},
-		"ClassEntropy": {
-			"function": "get_class_entropy"
-		},
-		"MeanCategoricalAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
-		},
-		"MinCategoricalAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
-		},
-		"Quartile1CategoricalAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
-		},
-		"Quartile2CategoricalAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
-		},
-		"Quartile3CategoricalAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
-		},
-		"MaxCategoricalAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
-		},
-		"MeanNumericAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
-		},
-		"MinNumericAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
-		},
-		"Quartile1NumericAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
-		},
-		"Quartile2NumericAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
-		},
-		"Quartile3NumericAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
-		},
-		"MaxNumericAttributeEntropy": {
-			"function": "get_attribute_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
-		},
-		"MeanCategoricalJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
-		},
-		"MinCategoricalJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
-		},
-		"Quartile1CategoricalJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
-		},
-		"Quartile2CategoricalJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
-		},
-		"Quartile3CategoricalJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
-		},
-		"MaxCategoricalJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
-		},
-		"MeanNumericJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
-		},
-		"MinNumericJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
-		},
-		"Quartile1NumericJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
-		},
-		"Quartile2NumericJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
-		},
-		"Quartile3NumericJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
-		},
-		"MaxNumericJointEntropy": {
-			"function": "get_joint_entropy",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
-		},
-		"MeanCategoricalMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
-		},
-		"MinCategoricalMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
-		},
-		"Quartile1CategoricalMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
-		},
-		"Quartile2CategoricalMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
-		},
-		"Quartile3CategoricalMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
-		},
-		"MaxCategoricalMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNCategoricalFeaturesAndClass"],
-			"returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
-		},
-		"MeanNumericMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
-		},
-		"MinNumericMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
-		},
-		"Quartile1NumericMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
-		},
-		"Quartile2NumericMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
-		},
-		"Quartile3NumericMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
-		},
-		"MaxNumericMutualInformation": {
-			"function": "get_mutual_information",
-			"parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
-			"returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
-		},
-		"EquivalentNumberOfCategoricalFeatures": {
-			"function": "get_equivalent_number_features",
-			"parameters": ["ClassEntropy","MeanCategoricalMutualInformation"],
-			"returns": ["EquivalentNumberOfCategoricalFeatures"]
-		},
-		"EquivalentNumberOfNumericFeatures": {
-			"function": "get_equivalent_number_features",
-			"parameters": ["ClassEntropy","MeanNumericMutualInformation"],
-			"returns": ["EquivalentNumberOfNumericFeatures"]
-		},
-		"CategoricalNoiseToSignalRatio": {
-			"function": "get_noise_signal_ratio",
-			"parameters": ["MeanCategoricalAttributeEntropy","MeanCategoricalMutualInformation"],
-			"returns": ["CategoricalNoiseToSignalRatio"]
-		},
-		"NumericNoiseToSignalRatio": {
-			"function": "get_noise_signal_ratio",
-			"parameters": ["MeanNumericAttributeEntropy","MeanNumericMutualInformation"],
-			"returns": ["NumericNoiseToSignalRatio"]
-		},
-		"NaiveBayesErrRate": {
-			"function": "get_naive_bayes"
-		},
-		"NaiveBayesKappa": {
-			"function": "get_naive_bayes"
-		},
-		"kNN1NErrRate": {
-			"function": "get_knn_1"
-		},
-		"kNN1NKappa": {
-			"function": "get_knn_1"
-		},
-		"DecisionStumpErrRate": {
-			"function": "get_decision_stump"
-		},
-		"DecisionStumpKappa": {
-			"function": "get_decision_stump"
-		},
-		"RandomTreeDepth1ErrRate": {
-			"function": "get_random_tree",
-			"parameters": ["XPreprocessed","YSample",1,"Seed"],
-			"seed_offset": 7,
-			"returns": ["RandomTreeDepth1ErrRate","RandomTreeDepth1Kappa"]
-		},
-		"RandomTreeDepth1Kappa": {
-			"function": "get_random_tree",
-			"parameters": ["XPreprocessed","YSample",1,"Seed"],
-			"seed_offset": 8,
-			"returns": ["RandomTreeDepth1ErrRate","RandomTreeDepth1Kappa"]
-		},
-		"RandomTreeDepth2ErrRate": {
-			"function": "get_random_tree",
-			"parameters": ["XPreprocessed","YSample",2,"Seed"],
-			"seed_offset": 9,
-			"returns": ["RandomTreeDepth2ErrRate","RandomTreeDepth2Kappa"]
-		},
-		"RandomTreeDepth2Kappa": {
-			"function": "get_random_tree",
-			"parameters": ["XPreprocessed","YSample",2,"Seed"],
-			"seed_offset": 10,
-			"returns": ["RandomTreeDepth2ErrRate","RandomTreeDepth2Kappa"]
-		},
-		"RandomTreeDepth3ErrRate": {
-			"function": "get_random_tree",
-			"parameters": ["XPreprocessed","YSample",3,"Seed"],
-			"seed_offset": 11,
-			"returns": ["RandomTreeDepth3ErrRate","RandomTreeDepth3Kappa"]
-		},
-		"RandomTreeDepth3Kappa": {
-			"function": "get_random_tree",
-			"parameters": ["XPreprocessed","YSample",3,"Seed"],
-			"seed_offset": 12,
-			"returns": ["RandomTreeDepth3ErrRate","RandomTreeDepth3Kappa"]
-		},
-		"LinearDiscriminantAnalysisErrRate": {
-			"function": "get_lda"
-		},
-		"LinearDiscriminantAnalysisKappa": {
-			"function": "get_lda"
-		}
-	}
+    "resources": {
+        "XRaw": {
+            "function": ""
+        },
+        "X": {
+            "function": ""
+        },
+        "Y": {
+            "function": ""
+        },
+        "ColumnTypes": {
+            "function": ""
+        },
+        "SampleRowsFlag": {
+            "function": ""
+        },
+        "SampleColumnsFlag": {
+            "function": ""
+        },
+        "Seed": {
+            "function": "self._get_random_seed"
+        },
+        "XSampledColumns": {
+            "function": "self._get_sample_of_columns"
+        },
+        "XSample": {
+            "function": "self._get_sample_of_rows"
+        },
+        "YSample": {
+            "function": "self._get_sample_of_rows"
+        },
+        "XPreprocessed": {
+            "function": "self._get_preprocessed_data"
+        },
+        "NoNaNCategoricalFeaturesAndClass": {
+            "function": "self._get_categorical_features_and_class_with_no_missing_values"
+        },
+        "NoNaNNumericFeaturesAndClass": {
+            "function": "self._get_numeric_features_and_class_with_no_missing_values"
+        },
+        "NoNaNBinnedNumericFeaturesAndClass": {
+            "function": "self._get_binned_numeric_features_and_class_with_no_missing_values"
+        }
+    },
+    "functions": {
+        "": {
+            "parameters": [],
+            "returns": []
+        },
+        "self._get_random_seed":{
+            "parameters": [],
+            "returns": ["Seed"]
+        },
+        "self._get_sample_of_columns": {
+            "parameters": ["X","SampleColumnsFlag","Seed"],
+            "seed_offset": 0,
+            "returns": ["XSampledColumns"]
+        },
+        "self._get_sample_of_rows": {
+            "parameters": ["XSampledColumns","Y","SampleRowsFlag", "Seed"],
+            "seed_offset": 1,
+            "returns": ["XSample","YSample"]
+        },
+        "self._get_preprocessed_data": {
+            "parameters": ["XSample","XSampledColumns", "ColumnTypes", "Seed"],
+            "seed_offset": 2,
+            "returns": ["XPreprocessed"]
+        },
+        "self._get_categorical_features_and_class_with_no_missing_values": {
+            "parameters": ["XSample","YSample", "ColumnTypes"],
+            "returns": ["NoNaNCategoricalFeaturesAndClass"]
+        },
+        "self._get_numeric_features_and_class_with_no_missing_values": {
+            "parameters": ["XSample","YSample", "ColumnTypes"],
+            "returns": ["NoNaNNumericFeaturesAndClass"]
+        },
+        "self._get_binned_numeric_features_and_class_with_no_missing_values": {
+            "parameters": ["NoNaNNumericFeaturesAndClass"],
+            "returns": ["NoNaNBinnedNumericFeaturesAndClass"]
+        },
+        "get_dataset_stats": {
+            "parameters": ["XRaw","Y", "ColumnTypes"],
+            "returns": ["NumberOfInstances","NumberOfFeatures","NumberOfClasses","NumberOfNumericFeatures","NumberOfCategoricalFeatures","RatioOfNumericFeatures","RatioOfCategoricalFeatures"]
+        },
+        "get_dimensionality": {
+            "parameters": ["NumberOfFeatures","NumberOfInstances"],
+            "returns": ["Dimensionality"]
+        },
+        "get_missing_values": {
+            "parameters": ["XRaw"],
+            "returns": ["NumberOfMissingValues","RatioOfMissingValues","NumberOfInstancesWithMissingValues","RatioOfInstancesWithMissingValues"]
+        },
+        "get_class_stats": {
+            "parameters": ["Y"],
+            "returns": ["MeanClassProbability","StdevClassProbability","MinClassProbability","MaxClassProbability","MinorityClassSize","MajorityClassSize"]
+        },
+        "get_categorical_cardinalities": {
+            "parameters": ["X", "ColumnTypes"],
+            "returns": ["MeanCardinalityOfCategoricalFeatures","StdevCardinalityOfCategoricalFeatures","MinCardinalityOfCategoricalFeatures","MaxCardinalityOfCategoricalFeatures"]
+        },
+        "get_numeric_cardinalities": {
+            "parameters": ["X", "ColumnTypes"],
+            "returns": ["MeanCardinalityOfNumericFeatures","StdevCardinalityOfNumericFeatures","MinCardinalityOfNumericFeatures","MaxCardinalityOfNumericFeatures"]
+        },
+        "get_numeric_means": {
+            "parameters": ["NoNaNNumericFeaturesAndClass"],
+            "returns": ["MeanMeansOfNumericFeatures","StdevMeansOfNumericFeatures","MinMeansOfNumericFeatures","Quartile1MeansOfNumericFeatures","Quartile2MeansOfNumericFeatures","Quartile3MeansOfNumericFeatures","MaxMeansOfNumericFeatures"]
+        },
+        "get_numeric_stdev": {
+            "parameters": ["NoNaNNumericFeaturesAndClass"],
+            "returns": ["MeanStdDevOfNumericFeatures","StdevStdDevOfNumericFeatures","MinStdDevOfNumericFeatures","Quartile1StdDevOfNumericFeatures","Quartile2StdDevOfNumericFeatures","Quartile3StdDevOfNumericFeatures","MaxStdDevOfNumericFeatures"]
+        },
+        "get_numeric_skewness": {
+            "parameters": ["NoNaNNumericFeaturesAndClass"],
+            "returns": ["MeanSkewnessOfNumericFeatures","StdevSkewnessOfNumericFeatures","MinSkewnessOfNumericFeatures","Quartile1SkewnessOfNumericFeatures","Quartile2SkewnessOfNumericFeatures","Quartile3SkewnessOfNumericFeatures","MaxSkewnessOfNumericFeatures"]
+        },
+        "get_numeric_kurtosis": {
+            "parameters": ["NoNaNNumericFeaturesAndClass"],
+            "returns": ["MeanKurtosisOfNumericFeatures","StdevKurtosisOfNumericFeatures","MinKurtosisOfNumericFeatures","Quartile1KurtosisOfNumericFeatures","Quartile2KurtosisOfNumericFeatures","Quartile3KurtosisOfNumericFeatures","MaxKurtosisOfNumericFeatures"]
+        },
+        "get_pca": {
+            "parameters": ["XPreprocessed"],
+            "returns": ["PredPCA1","PredPCA2","PredPCA3","PredEigen1","PredEigen2","PredEigen3","PredDet"]
+        },
+        "get_correlations": {
+            "parameters": ["XSample", "ColumnTypes"],
+            "returns": ["MeanCanonicalCorrelation","StdevCanonicalCorrelation"]
+        },
+        "get_class_entropy": {
+            "parameters": ["YSample"],
+            "returns": ["ClassEntropy"]
+        },
+        "get_attribute_entropy": {
+            "parameters": [],
+            "returns": []
+        },
+        "get_joint_entropy": {
+            "parameters": [],
+            "returns": []
+        },
+        "get_mutual_information": {
+            "parameters": [],
+            "returns": []
+        },
+        "get_equivalent_number_features": {
+            "parameters": [],
+            "returns": []
+        },
+        "get_noise_signal_ratio": {
+            "parameters": [],
+            "returns": []
+        },
+        "get_naive_bayes": {
+            "parameters": ["XPreprocessed","YSample", "Seed"],
+            "seed_offset": 3,
+            "returns": ["NaiveBayesErrRate","NaiveBayesKappa"]
+        },
+        "get_knn_1": {
+            "parameters": ["XPreprocessed","YSample", "Seed"],
+            "seed_offset": 4,
+            "returns": ["kNN1NErrRate","kNN1NKappa"]
+        },
+        "get_decision_stump": {
+            "parameters": ["XPreprocessed","YSample","Seed"],
+            "seed_offset": 5,
+            "returns": ["DecisionStumpErrRate","DecisionStumpKappa"]
+        },
+        "get_random_tree": {
+            "parameters": [],
+            "seed_offset": null,
+            "returns": []
+        },
+        "get_lda": {
+            "parameters": ["XPreprocessed","YSample", "Seed"],
+            "seed_offset": 6,
+            "returns": ["LinearDiscriminantAnalysisErrRate","LinearDiscriminantAnalysisKappa"]
+        }
+    },
+    "metafeatures": {
+        "NumberOfInstances": {
+            "function": "get_dataset_stats"
+        },
+        "NumberOfFeatures": {
+            "function": "get_dataset_stats"
+        },
+        "NumberOfClasses": {
+            "function": "get_dataset_stats"
+        },
+        "NumberOfNumericFeatures": {
+            "function": "get_dataset_stats"
+        },
+        "NumberOfCategoricalFeatures": {
+            "function": "get_dataset_stats"
+        },
+        "RatioOfNumericFeatures": {
+            "function": "get_dataset_stats"
+        },
+        "RatioOfCategoricalFeatures": {
+            "function": "get_dataset_stats"
+        },
+        "Dimensionality": {
+            "function": "get_dimensionality"
+        },
+        "NumberOfMissingValues": {
+            "function": "get_missing_values"
+        },
+        "RatioOfMissingValues": {
+            "function": "get_missing_values"
+        },
+        "NumberOfInstancesWithMissingValues": {
+            "function": "get_missing_values"
+        },
+        "RatioOfInstancesWithMissingValues": {
+            "function": "get_missing_values"
+        },
+        "MeanClassProbability": {
+            "function": "get_class_stats"
+        },
+        "StdevClassProbability": {
+            "function": "get_class_stats"
+        },
+        "MinClassProbability": {
+            "function": "get_class_stats"
+        },
+        "MaxClassProbability": {
+            "function": "get_class_stats"
+        },
+        "MinorityClassSize": {
+            "function": "get_class_stats"
+        },
+        "MajorityClassSize": {
+            "function": "get_class_stats"
+        },
+        "MeanCardinalityOfCategoricalFeatures": {
+            "function": "get_categorical_cardinalities"
+        },
+        "StdevCardinalityOfCategoricalFeatures": {
+            "function": "get_categorical_cardinalities"
+        },
+        "MinCardinalityOfCategoricalFeatures": {
+            "function": "get_categorical_cardinalities"
+        },
+        "MaxCardinalityOfCategoricalFeatures": {
+            "function": "get_categorical_cardinalities"
+        },
+        "MeanCardinalityOfNumericFeatures": {
+            "function": "get_numeric_cardinalities"
+        },
+        "StdevCardinalityOfNumericFeatures": {
+            "function": "get_numeric_cardinalities"
+        },
+        "MinCardinalityOfNumericFeatures": {
+            "function": "get_numeric_cardinalities"
+        },
+        "MaxCardinalityOfNumericFeatures": {
+            "function": "get_numeric_cardinalities"
+        },
+        "MeanMeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "StdevMeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "MinMeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "MaxMeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "Quartile1MeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "Quartile2MeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "Quartile3MeansOfNumericFeatures": {
+            "function": "get_numeric_means"
+        },
+        "MeanStdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "StdevStdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "MinStdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "MaxStdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "Quartile1StdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "Quartile2StdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "Quartile3StdDevOfNumericFeatures": {
+            "function": "get_numeric_stdev"
+        },
+        "MeanSkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "StdevSkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "MinSkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "MaxSkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "Quartile1SkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "Quartile2SkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "Quartile3SkewnessOfNumericFeatures": {
+            "function": "get_numeric_skewness"
+        },
+        "MeanKurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "StdevKurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "MinKurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "MaxKurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "Quartile1KurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "Quartile2KurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "Quartile3KurtosisOfNumericFeatures": {
+            "function": "get_numeric_kurtosis"
+        },
+        "PredPCA1": {
+            "function": "get_pca"
+        },
+        "PredPCA2": {
+            "function": "get_pca"
+        },
+        "PredPCA3": {
+            "function": "get_pca"
+        },
+        "PredEigen1": {
+            "function": "get_pca"
+        },
+        "PredEigen2": {
+            "function": "get_pca"
+        },
+        "PredEigen3": {
+            "function": "get_pca"
+        },
+        "PredDet": {
+            "function": "get_pca"
+        },
+        "MeanCanonicalCorrelation": {
+            "function": "get_correlations"
+        },
+        "StdevCanonicalCorrelation": {
+            "function": "get_correlations"
+        },
+        "ClassEntropy": {
+            "function": "get_class_entropy"
+        },
+        "MeanCategoricalAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
+        },
+        "MinCategoricalAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
+        },
+        "Quartile1CategoricalAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
+        },
+        "Quartile2CategoricalAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
+        },
+        "Quartile3CategoricalAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
+        },
+        "MaxCategoricalAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalAttributeEntropy","MinCategoricalAttributeEntropy","Quartile1CategoricalAttributeEntropy","Quartile2CategoricalAttributeEntropy","Quartile3CategoricalAttributeEntropy","MaxCategoricalAttributeEntropy"]
+        },
+        "MeanNumericAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
+        },
+        "MinNumericAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
+        },
+        "Quartile1NumericAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
+        },
+        "Quartile2NumericAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
+        },
+        "Quartile3NumericAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
+        },
+        "MaxNumericAttributeEntropy": {
+            "function": "get_attribute_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericAttributeEntropy","MinNumericAttributeEntropy","Quartile1NumericAttributeEntropy","Quartile2NumericAttributeEntropy","Quartile3NumericAttributeEntropy","MaxNumericAttributeEntropy"]
+        },
+        "MeanCategoricalJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
+        },
+        "MinCategoricalJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
+        },
+        "Quartile1CategoricalJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
+        },
+        "Quartile2CategoricalJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
+        },
+        "Quartile3CategoricalJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
+        },
+        "MaxCategoricalJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalJointEntropy","MinCategoricalJointEntropy","Quartile1CategoricalJointEntropy","Quartile2CategoricalJointEntropy","Quartile3CategoricalJointEntropy","MaxCategoricalJointEntropy"]
+        },
+        "MeanNumericJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
+        },
+        "MinNumericJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
+        },
+        "Quartile1NumericJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
+        },
+        "Quartile2NumericJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
+        },
+        "Quartile3NumericJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
+        },
+        "MaxNumericJointEntropy": {
+            "function": "get_joint_entropy",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericJointEntropy","MinNumericJointEntropy","Quartile1NumericJointEntropy","Quartile2NumericJointEntropy","Quartile3NumericJointEntropy","MaxNumericJointEntropy"]
+        },
+        "MeanCategoricalMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
+        },
+        "MinCategoricalMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
+        },
+        "Quartile1CategoricalMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
+        },
+        "Quartile2CategoricalMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
+        },
+        "Quartile3CategoricalMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
+        },
+        "MaxCategoricalMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNCategoricalFeaturesAndClass"],
+            "returns": ["MeanCategoricalMutualInformation","MinCategoricalMutualInformation","Quartile1CategoricalMutualInformation","Quartile2CategoricalMutualInformation","Quartile3CategoricalMutualInformation","MaxCategoricalMutualInformation"]
+        },
+        "MeanNumericMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
+        },
+        "MinNumericMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
+        },
+        "Quartile1NumericMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
+        },
+        "Quartile2NumericMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
+        },
+        "Quartile3NumericMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
+        },
+        "MaxNumericMutualInformation": {
+            "function": "get_mutual_information",
+            "parameters": ["NoNaNBinnedNumericFeaturesAndClass"],
+            "returns": ["MeanNumericMutualInformation","MinNumericMutualInformation","Quartile1NumericMutualInformation","Quartile2NumericMutualInformation","Quartile3NumericMutualInformation","MaxNumericMutualInformation"]
+        },
+        "EquivalentNumberOfCategoricalFeatures": {
+            "function": "get_equivalent_number_features",
+            "parameters": ["ClassEntropy","MeanCategoricalMutualInformation"],
+            "returns": ["EquivalentNumberOfCategoricalFeatures"]
+        },
+        "EquivalentNumberOfNumericFeatures": {
+            "function": "get_equivalent_number_features",
+            "parameters": ["ClassEntropy","MeanNumericMutualInformation"],
+            "returns": ["EquivalentNumberOfNumericFeatures"]
+        },
+        "CategoricalNoiseToSignalRatio": {
+            "function": "get_noise_signal_ratio",
+            "parameters": ["MeanCategoricalAttributeEntropy","MeanCategoricalMutualInformation"],
+            "returns": ["CategoricalNoiseToSignalRatio"]
+        },
+        "NumericNoiseToSignalRatio": {
+            "function": "get_noise_signal_ratio",
+            "parameters": ["MeanNumericAttributeEntropy","MeanNumericMutualInformation"],
+            "returns": ["NumericNoiseToSignalRatio"]
+        },
+        "NaiveBayesErrRate": {
+            "function": "get_naive_bayes"
+        },
+        "NaiveBayesKappa": {
+            "function": "get_naive_bayes"
+        },
+        "kNN1NErrRate": {
+            "function": "get_knn_1"
+        },
+        "kNN1NKappa": {
+            "function": "get_knn_1"
+        },
+        "DecisionStumpErrRate": {
+            "function": "get_decision_stump"
+        },
+        "DecisionStumpKappa": {
+            "function": "get_decision_stump"
+        },
+        "RandomTreeDepth1ErrRate": {
+            "function": "get_random_tree",
+            "parameters": ["XPreprocessed","YSample",1,"Seed"],
+            "seed_offset": 7,
+            "returns": ["RandomTreeDepth1ErrRate","RandomTreeDepth1Kappa"]
+        },
+        "RandomTreeDepth1Kappa": {
+            "function": "get_random_tree",
+            "parameters": ["XPreprocessed","YSample",1,"Seed"],
+            "seed_offset": 8,
+            "returns": ["RandomTreeDepth1ErrRate","RandomTreeDepth1Kappa"]
+        },
+        "RandomTreeDepth2ErrRate": {
+            "function": "get_random_tree",
+            "parameters": ["XPreprocessed","YSample",2,"Seed"],
+            "seed_offset": 9,
+            "returns": ["RandomTreeDepth2ErrRate","RandomTreeDepth2Kappa"]
+        },
+        "RandomTreeDepth2Kappa": {
+            "function": "get_random_tree",
+            "parameters": ["XPreprocessed","YSample",2,"Seed"],
+            "seed_offset": 10,
+            "returns": ["RandomTreeDepth2ErrRate","RandomTreeDepth2Kappa"]
+        },
+        "RandomTreeDepth3ErrRate": {
+            "function": "get_random_tree",
+            "parameters": ["XPreprocessed","YSample",3,"Seed"],
+            "seed_offset": 11,
+            "returns": ["RandomTreeDepth3ErrRate","RandomTreeDepth3Kappa"]
+        },
+        "RandomTreeDepth3Kappa": {
+            "function": "get_random_tree",
+            "parameters": ["XPreprocessed","YSample",3,"Seed"],
+            "seed_offset": 12,
+            "returns": ["RandomTreeDepth3ErrRate","RandomTreeDepth3Kappa"]
+        },
+        "LinearDiscriminantAnalysisErrRate": {
+            "function": "get_lda"
+        },
+        "LinearDiscriminantAnalysisKappa": {
+            "function": "get_lda"
+        }
+    }
 }

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 
+
 from .common_operations import *
 from .simple_metafeatures import *
 from .statistical_metafeatures import *

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -262,7 +262,7 @@ class Metafeatures(object):
             total_time += time_value
         return (retrieved_parameters, total_time)
 
-    def _get_preprocessed_data(self, X_sample, X_sampled_columns, seed=42):
+    def _get_preprocessed_data(self, X_sample, X_sampled_columns, column_types, seed=42):
         series_array = []
         for feature in X_sample.columns:
             feature_series = X_sample[feature]
@@ -275,7 +275,7 @@ class Metafeatures(object):
             col[feature_series.isnull()] = np.random.choice(
                 dropped_nan_series, num_nan
             )
-            if not dtype_is_numeric(feature_series.dtype):
+            if column_types[feature_series.name] == self.CATEGORICAL:
                 feature_series = pd.get_dummies(feature_series)
             series_array.append(feature_series)
         return (pd.concat(series_array, axis=1, copy=False),)

--- a/metalearn/metafeatures/simple_metafeatures.py
+++ b/metalearn/metafeatures/simple_metafeatures.py
@@ -34,12 +34,12 @@ def get_class_stats(Y):
     minority_class_size = min(counts)
     return (mean_class_probability, stdev_class_probability, min_class_probability, max_class_probability, minority_class_size, majority_class_size)
 
-def get_categorical_cardinalities(X):
-    cardinalities = [X[feature].unique().shape[0] for feature in X.columns if not dtype_is_numeric(X[feature].dtype)]
+def get_categorical_cardinalities(X, column_types):
+    cardinalities = [X[feature].unique().shape[0] for feature in get_categorical_features(X, column_types)]
     mean_cardinality_of_categorical_features, stdev_cardinality_of_categorical_features, min_cardinality_of_categorical_features, _, _, _, max_cardinality_of_categorical_features = profile_distribution(cardinalities)
     return (mean_cardinality_of_categorical_features, stdev_cardinality_of_categorical_features, min_cardinality_of_categorical_features, max_cardinality_of_categorical_features)
 
-def get_numeric_cardinalities(X):
-    cardinalities = [X[feature].unique().shape[0] for feature in X.columns if dtype_is_numeric(X[feature].dtype)]
+def get_numeric_cardinalities(X, column_types):
+    cardinalities = [X[feature].unique().shape[0] for feature in get_numeric_features(X, column_types)]
     mean_cardinality_of_numeric_features, stdev_cardinality_of_numeric_features, min_cardinality_of_numeric_features, _, _, _, max_cardinality_of_numeric_features = profile_distribution(cardinalities)
     return (mean_cardinality_of_numeric_features, stdev_cardinality_of_numeric_features, min_cardinality_of_numeric_features, max_cardinality_of_numeric_features)

--- a/metalearn/metafeatures/statistical_metafeatures.py
+++ b/metalearn/metafeatures/statistical_metafeatures.py
@@ -71,7 +71,7 @@ def get_canonical_correlations(dataframe, column_types):
     '''
 
     def preprocess(series):
-        if not dtype_is_numeric(series.dtype):
+        if column_types[series.name] == 'CATEGORICAL':
             series = pd.get_dummies(series)
         array = series.as_matrix().reshape(series.shape[0], -1)
         return array

--- a/metalearn/metafeatures/statistical_metafeatures.py
+++ b/metalearn/metafeatures/statistical_metafeatures.py
@@ -30,14 +30,14 @@ def get_numeric_kurtosis(numeric_features_class_array):
     kurtoses = [feature_class_pair[0].kurtosis() for feature_class_pair in numeric_features_class_array]
     return profile_distribution(kurtoses)
 
-def get_pca(X_preprocessed):    
+def get_pca(X_preprocessed):
     num_components = min(3, X_preprocessed.shape[1])
     pca_data = PCA(n_components=num_components)
     pca_data.fit_transform(X_preprocessed.as_matrix())
     pred_pca = pca_data.explained_variance_ratio_
     pred_eigen = pca_data.explained_variance_
     pred_det = np.linalg.det(pca_data.get_covariance())
-    variance_percentages = [np.nan] * 3    
+    variance_percentages = [np.nan] * 3
     for i in range(len(pred_pca)):
         variance_percentages[i] = pred_pca[i]
     eigenvalues = [np.nan] * 3
@@ -80,7 +80,7 @@ def get_canonical_correlations(dataframe, column_types):
     if len(numeric_features) < 2:
         return []
     dataframe = dataframe[numeric_features]
-    
+
     correlations = []
     skip_cols = set()
     for col_name_i, col_name_j in itertools.combinations(dataframe.columns, 2):


### PR DESCRIPTION
changed the paramaters of those two functions in metafeatures.json, and changed the corresponding functions in simple_metafeatures.py.  Added a new "get_categorical_features" function to common_operations.py