### PR TITLE
Soft timeout

### DIFF
--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -208,10 +208,6 @@ class Metafeatures(object):
     def _get_cv_seed(self, seed_base, seed_offset):
         return (seed_base + seed_offset,)
 
-    # def _check_timeout(self):
-    #     if time.time() - self.start_time > self.timeout:
-    #         raise TimeoutError()
-
     def _validate_compute_arguments(
         self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
         verbose

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -135,6 +135,7 @@ class Metafeatures(object):
                                  for name in metafeature_ids}
         try:
             for metafeature_id in metafeature_ids:
+                self._check_timeout()
                 if verbose:
                     print(metafeature_id)
                 if self._resource_is_target_dependent(metafeature_id) and (
@@ -152,7 +153,6 @@ class Metafeatures(object):
                     self.VALUE_KEY: value,
                     self.COMPUTE_TIME_KEY: compute_time
                 }
-                self._check_timeout()
         except TimeoutError:
             pass
 

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -88,6 +88,10 @@ class Metafeatures(object):
             landmarking metafeatures. also affects the sample_shape validation
         verbose: bool, default False. When True, prints the ID of each
             metafeature right before it is about to be computed.
+        timeout: float, default None. If timeout is None, compute_metafeatures
+            will be run to completion. Otherwise, execution will halt after
+            approximately timeout seconds. Any metafeatures that have not been
+            computed will be labeled 'TIMEOUT'.
 
         Returns
         -------
@@ -131,7 +135,7 @@ class Metafeatures(object):
                                  for name in metafeature_ids}
         try:
             for metafeature_id in metafeature_ids:
-                if verbose == True:
+                if verbose:
                     print(metafeature_id)
                 if self._resource_is_target_dependent(metafeature_id) and (
                     Y is None or column_types[Y.name] == self.NUMERIC

--- a/test/metalearn/metafeatures/test_metafeatures.py
+++ b/test/metalearn/metafeatures/test_metafeatures.py
@@ -124,13 +124,13 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
 
         master_diffs = master_mf_ids_set - intersect_mf_ids_set
         if len(master_diffs) > 0:
-            test_failures["master_differences"] = list(master_names_unique)
+            test_failures["master_differences"] = list(master_diffs)
         known_diffs = known_mf_ids_set - intersect_mf_ids_set
         if len(known_diffs) > 0:
-            test_failures["known_differences"] = list(known_names_unique)
+            test_failures["known_differences"] = list(known_diffs)
         computed_diffs = computed_mf_ids_set - intersect_mf_ids_set
         if len(computed_diffs) > 0:
-            test_failures["computed_differences"] = list(computed_names_unique)
+            test_failures["computed_differences"] = list(computed_diffs)
 
         return self._format_check_report(
             "metafeature_lists", fail_message, test_failures, filename
@@ -336,31 +336,32 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
         """Tests Metafeatures().compute() with timeout set"""   
         test_name = inspect.stack()[0][3]   
         test_failures = {} 
-        for timeout in [.2,.4,.6,.8,1]:  
+        for timeout in [.05, .1, .15, .2, .25, .3, .35, .4, .45, .5, None]:
             for dataset_filename, dataset in self.datasets.items(): 
                 metafeatures = Metafeatures()   
                 start_time = time.time()    
                 computed_mfs = metafeatures.compute(  
                     X=dataset["X"], Y=dataset["Y"], seed=CORRECTNESS_SEED,
-                    column_types=dataset["column_types"] ,timeout=timeout
+                    column_types=dataset["column_types"], timeout=timeout
                 )   
                 compute_time = time.time() - start_time 
-                self.assertGreater( 
-                    timeout, compute_time,  
-                    f"Compute metafeatures exceeded timeout on '{dataset_filename}'"    
-                )  
-                computed_mfs = {k:v for k,v in computed_mfs.items() if v[Metafeatures.VALUE_KEY] != Metafeatures.TIMEOUT}
+                print(f"Dataset: {dataset_filename} time: {compute_time}")
+                # self.assertGreater( 
+                #     timeout, compute_time,  
+                #     f"Compute metafeatures exceeded timeout on '{dataset_filename}'"    
+                # )  
+                computed_mfs_timeout = {k: v for k, v in computed_mfs.items() if v[Metafeatures.VALUE_KEY] != Metafeatures.TIMEOUT}
                 known_mfs = dataset["known_metafeatures"]
                 required_checks = {
-                self._check_correctness: [
-                    computed_mfs, known_mfs, dataset_filename
-                ],
-                self._check_compare_metafeature_lists: [
-                    computed_mfs, known_mfs, dataset_filename
-                ]
-            }
+                    self._check_correctness: [
+                        computed_mfs_timeout, known_mfs, dataset_filename
+                    ],
+                    self._check_compare_metafeature_lists: [
+                        computed_mfs, known_mfs, dataset_filename
+                    ]
+                }
             test_failures.update(self._perform_checks(required_checks))
-
+            print()
         self._report_test_failures(test_failures, test_name)
 
 

--- a/test/metalearn/metafeatures/test_metafeatures.py
+++ b/test/metalearn/metafeatures/test_metafeatures.py
@@ -351,10 +351,10 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
                 X=dataset["X"], Y=dataset["Y"], seed=CORRECTNESS_SEED,
                 column_types=dataset["column_types"], timeout=full_compute_time/2
             )
-            compute_time = time.time() - start_time
+            limited_compute_time = time.time() - start_time
 
             self.assertGreater(
-                full_compute_time, compute_time,
+                full_compute_time, limited_compute_time,
                 f"Compute metafeatures exceeded timeout on '{dataset_filename}'"
             )
             computed_mfs_timeout = {k: v for k, v in computed_mfs.items()


### PR DESCRIPTION
Soft timeout is implemented as a function that is only defined when timeout is not None. Currently compute only checks the timeout inside get_resources and after each metafeature is computed. To check in more places, just add self._check_timeout(). Closes #138 