### PR TITLE
Exclude metafeatures

### DIFF
--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -72,23 +72,23 @@ class Metafeatures(object):
         Parameters
         ----------
         X: pandas.DataFrame, the dataset features
-        Y: pandas.Seris, the dataset targets
+        Y: pandas.Series, the dataset targets
         column_types: Dict[str, str], dict from column name to column type as
             "NUMERIC" or "CATEGORICAL", must include Y column
         metafeature_ids: list, the metafeatures to compute. default of None
             indicates to compute all metafeatures
         sample_shape: tuple, the shape of X after sampling (X,Y) uniformly.
             Default is (None, None), indicate not to sample rows or columns.
-        seed: int, the seed used to generate psuedo-random numbers. when None
-            is given, a seed will be generated psuedo-randomly. this can be
+        seed: int, the seed used to generate pseudo-random numbers. when None
+            is given, a seed will be generated pseudo-randomly. this can be
             used for reproducibility of metafeatures. a generated seed can be
             accessed through the 'seed' property, after calling this method.
         n_folds: int, the number of cross validation folds used by the
             landmarking metafeatures. also affects the sample_shape validation
         verbose: bool, default False. When True, prints the ID of each
             metafeature right before it is about to be computed.
-        exclude: list, the metafeatures to be excluded from computation. Must
-            None if metafeature_ids is not None. Default None.
+        exclude: list, default None. The metafeatures to be excluded from computation.
+            Must be None if metafeature_ids is not None.
 
         Returns
         -------
@@ -202,7 +202,7 @@ class Metafeatures(object):
         for f in [
             self._validate_X, self._validate_Y, self._validate_column_types,
             self._validate_metafeature_ids, self._validate_sample_shape,
-            self._validate_n_folds, self._validate_verbose, self._validate_excluded_ids
+            self._validate_n_folds, self._validate_verbose
         ]:
             f(
                 X, Y, column_types, metafeature_ids, sample_shape, seed,
@@ -252,13 +252,22 @@ class Metafeatures(object):
     ):
         if metafeature_ids is not None and exclude is not None:
             raise ValueError("metafeature_ids and exclude cannot both be non-null")
-        if metafeature_ids is not None:
+        elif metafeature_ids is not None:
             invalid_metafeature_ids = [
                 mf for mf in metafeature_ids if mf not in self._resources_info
             ]
             if len(invalid_metafeature_ids) > 0:
                 raise ValueError(
                     'One or more requested metafeatures are not valid: {}'.
+                    format(invalid_metafeature_ids)
+                )
+        elif exclude is not None:
+            invalid_metafeature_ids = [
+                mf for mf in exclude if mf not in self._resources_info
+            ]
+            if len(invalid_metafeature_ids) > 0:
+                raise ValueError(
+                    'One or more excluded metafeatures are not valid: {}'.
                     format(invalid_metafeature_ids)
                 )
 
@@ -314,22 +323,6 @@ class Metafeatures(object):
     ):
         if not type(verbose) is bool:
             raise ValueError("`verbose` must be of type bool.")
-
-    def _validate_excluded_ids(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
-    ):
-        if metafeature_ids is not None and exclude is not None:
-            raise ValueError("metafeature_ids and exclude cannot both be non-null")
-        if exclude is not None:
-            invalid_metafeature_ids = [
-                mf for mf in exclude if mf not in self._resources_info
-            ]
-            if len(invalid_metafeature_ids) > 0:
-                raise ValueError(
-                    'One or more excluded metafeatures are not valid: {}'.
-                    format(invalid_metafeature_ids)
-                )
 
     def _infer_column_types(self, X, Y):
         column_types = {}

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -64,9 +64,9 @@ class Metafeatures(object):
             raise ValueError(f"Unknown group {group}")
 
     def compute(
-        self, X: DataFrame, Y: Series = None,
-        column_types: Dict[str, str] = None, metafeature_ids: List = None,
-        sample_shape=None, seed=None, n_folds=2, verbose=False, exclude: List=None
+        self, X: DataFrame, Y: Series=None,
+        column_types: Dict[str, str]=None, metafeature_ids: List=None,
+        exclude: List=None, sample_shape=None, seed=None, n_folds=2, verbose=False
     ) -> dict:
         """
         Parameters
@@ -77,6 +77,8 @@ class Metafeatures(object):
             "NUMERIC" or "CATEGORICAL", must include Y column
         metafeature_ids: list, the metafeatures to compute. default of None
             indicates to compute all metafeatures
+        exclude: list, default None. The metafeatures to be excluded from computation.
+            Must be None if metafeature_ids is not None.
         sample_shape: tuple, the shape of X after sampling (X,Y) uniformly.
             Default is (None, None), indicate not to sample rows or columns.
         seed: int, the seed used to generate pseudo-random numbers. when None
@@ -87,8 +89,6 @@ class Metafeatures(object):
             landmarking metafeatures. also affects the sample_shape validation
         verbose: bool, default False. When True, prints the ID of each
             metafeature right before it is about to be computed.
-        exclude: list, default None. The metafeatures to be excluded from computation.
-            Must be None if metafeature_ids is not None.
 
         Returns
         -------
@@ -98,8 +98,8 @@ class Metafeatures(object):
         indicating a reason why the value could not be computed.
         """
         self._validate_compute_arguments(
-            X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-            verbose, exclude
+            X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+            n_folds, verbose
         )
         if column_types is None:
             column_types = self._infer_column_types(X, Y)
@@ -111,12 +111,12 @@ class Metafeatures(object):
         if seed is None:
             seed = np.random.randint(2**32)
         self._validate_compute_arguments(
-            X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-            verbose, exclude
+            X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+            n_folds, verbose
         )
 
         self._init_resources(
-            X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds, exclude
+            X, Y, column_types, sample_shape, seed, n_folds
         )
 
         computed_metafeatures = {}
@@ -142,7 +142,7 @@ class Metafeatures(object):
         return computed_metafeatures
 
     def _init_resources(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds, exclude
+        self, X, Y, column_types, sample_shape, seed, n_folds
     ):
         self._resources = {
             "X_raw": {
@@ -196,8 +196,8 @@ class Metafeatures(object):
         return (seed_base + seed_offset,)
 
     def _validate_compute_arguments(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         for f in [
             self._validate_X, self._validate_Y, self._validate_column_types,
@@ -205,27 +205,27 @@ class Metafeatures(object):
             self._validate_n_folds, self._validate_verbose
         ]:
             f(
-                X, Y, column_types, metafeature_ids, sample_shape, seed,
-                n_folds, verbose, exclude
+                X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+                n_folds, verbose
             )
 
     def _validate_X(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         if not isinstance(X, pd.DataFrame):
             raise TypeError('X must be of type pandas.DataFrame')
 
     def _validate_Y(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         if not isinstance(Y, pd.Series) and not Y is None:
             raise TypeError('Y must be of type pandas.Series')
 
     def _validate_column_types(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         if not column_types is None:
             invalid_column_types = {}
@@ -247,33 +247,31 @@ class Metafeatures(object):
                 )
 
     def _validate_metafeature_ids(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
+        ids = None
         if metafeature_ids is not None and exclude is not None:
             raise ValueError("metafeature_ids and exclude cannot both be non-null")
         elif metafeature_ids is not None:
-            invalid_metafeature_ids = [
-                mf for mf in metafeature_ids if mf not in self._resources_info
-            ]
-            if len(invalid_metafeature_ids) > 0:
-                raise ValueError(
-                    'One or more requested metafeatures are not valid: {}'.
-                    format(invalid_metafeature_ids)
-                )
+            ids = metafeature_ids
+            list_label = 'requested'
         elif exclude is not None:
+            ids = exclude
+            list_label = 'excluded'
+        if ids is not None:
             invalid_metafeature_ids = [
-                mf for mf in exclude if mf not in self._resources_info
+                mf for mf in ids if mf not in self._resources_info
             ]
             if len(invalid_metafeature_ids) > 0:
                 raise ValueError(
-                    'One or more excluded metafeatures are not valid: {}'.
-                    format(invalid_metafeature_ids)
+                    'One or more {} metafeatures are not valid: {}'.
+                    format(list_label, invalid_metafeature_ids)
                 )
 
     def _validate_sample_shape(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         if not sample_shape is None:
             if not type(sample_shape) in [tuple, list]:
@@ -294,8 +292,8 @@ class Metafeatures(object):
                     )
 
     def _validate_n_folds(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         if not dtype_is_numeric(type(n_folds)) or (n_folds != int(n_folds)):
             raise ValueError(f"`n_folds` must be an integer, not {n_folds}")
@@ -318,8 +316,8 @@ class Metafeatures(object):
                         )
 
     def _validate_verbose(
-        self, X, Y, column_types, metafeature_ids, sample_shape, seed, n_folds,
-        verbose, exclude
+        self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
+        n_folds, verbose
     ):
         if not type(verbose) is bool:
             raise ValueError("`verbose` must be of type bool.")

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -348,7 +348,6 @@ class Metafeatures(object):
     def _set_metafeature_ids(self, exclude):
         if exclude is not None:
             return [mf for mf in self.list_metafeatures() if mf not in exclude]
-
         else:
             return self.list_metafeatures()
 

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -104,7 +104,7 @@ class Metafeatures(object):
         if column_types is None:
             column_types = self._infer_column_types(X, Y)
         if metafeature_ids is None:
-            metafeature_ids = self._set_metafeature_ids(exclude)
+            metafeature_ids = self._get_metafeature_ids(exclude)
             exclude = None
         if sample_shape is None:
             sample_shape = (None, None)
@@ -336,7 +336,7 @@ class Metafeatures(object):
                 column_types[Y.name] = self.CATEGORICAL
         return column_types
 
-    def _set_metafeature_ids(self, exclude):
+    def _get_metafeature_ids(self, exclude):
         if exclude is not None:
             return [mf for mf in self.list_metafeatures() if mf not in exclude]
         else:

--- a/test/metalearn/metafeatures/test_metafeatures.py
+++ b/test/metalearn/metafeatures/test_metafeatures.py
@@ -255,6 +255,29 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
         self._report_test_failures(test_failures, test_name)
 
+    def test_exclude_metafeatures(self):
+        SUBSET_LENGTH = 20
+        test_failures = {}
+        test_name = inspect.stack()[0][3]
+        for dataset_filename, dataset in self.datasets.items():
+            metafeature_ids = random.sample(Metafeatures.IDS, SUBSET_LENGTH)
+            computed_mfs = Metafeatures().compute(
+                X=dataset["X"], Y=dataset["Y"], seed=CORRECTNESS_SEED,
+                exclude=metafeature_ids,
+                column_types=dataset["column_types"]
+            )
+            known_metafeatures = dataset["known_metafeatures"]
+            required_checks = {
+                self._check_correctness: [
+                    computed_mfs, known_metafeatures, dataset_filename
+                ]
+            }
+            test_failures.update(self._perform_checks(required_checks))
+            if any(mf_id in computed_mfs.keys() for mf_id in metafeature_ids):
+                self.assertTrue(False, "Metafeatures computed an excluded metafeature")
+
+        self._report_test_failures(test_failures, test_name)
+
     def test_compute_effects_on_dataset(self):
         """
         Tests whether computing metafeatures has any side effects on the input
@@ -331,6 +354,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
                 self.fail(
                     f"Failed to convert metafeature output to json: {str(e)}"
                 )
+
 
 
 class MetafeaturesTestCase(unittest.TestCase):


### PR DESCRIPTION
Closes #125. Raises an exception if any metafeature ids are invalid or if metafeature_ids and exclude are both non-null