### PR TITLE
Fixes Joint Entropy Bug

### DIFF
--- a/metalearn/metafeatures/information_theoretic_metafeatures.py
+++ b/metalearn/metafeatures/information_theoretic_metafeatures.py
@@ -16,7 +16,6 @@ def get_attribute_entropy(feature_array):
     return (mean_attribute_entropy, min_attribute_entropy, quartile1_attribute_entropy, quartile2_attribute_entropy, quartile3_attribute_entropy, max_attribute_entropy)
 
 def get_joint_entropy(feature_class_array):
-    #feature_class_pair[0].astype(str) + feature_class_pair[1].astype(str)
     entropies = [get_entropy(translate_into_tuples(feature_class_pair[0],feature_class_pair[1])) for feature_class_pair in feature_class_array]
     mean_joint_entropy, _, min_joint_entropy, quartile1_joint_entropy, quartile2_joint_entropy, quartile3_joint_entropy, max_joint_entropy = profile_distribution(entropies)
     return (mean_joint_entropy, min_joint_entropy, quartile1_joint_entropy, quartile2_joint_entropy, quartile3_joint_entropy, max_joint_entropy)
@@ -41,8 +40,4 @@ def get_noise_signal_ratio(attribute_entropy, mutual_information):
     return (nsr,)
 
 def translate_into_tuples(col1, col2):
-    col3 = []
-    for (k,v), (k2,v2) in zip(col1.items(),col2.items()):
-        t = (v,v2)
-        col3.append(t)
-    return pd.Series(col3);
+    return pd.Series([x for x in zip(col1, col2)])

--- a/metalearn/metafeatures/information_theoretic_metafeatures.py
+++ b/metalearn/metafeatures/information_theoretic_metafeatures.py
@@ -16,7 +16,8 @@ def get_attribute_entropy(feature_array):
     return (mean_attribute_entropy, min_attribute_entropy, quartile1_attribute_entropy, quartile2_attribute_entropy, quartile3_attribute_entropy, max_attribute_entropy)
 
 def get_joint_entropy(feature_class_array):
-    entropies = [get_entropy(feature_class_pair[0].astype(str) + feature_class_pair[1].astype(str)) for feature_class_pair in feature_class_array]
+    #feature_class_pair[0].astype(str) + feature_class_pair[1].astype(str)
+    entropies = [get_entropy(translate_into_tuples(feature_class_pair[0],feature_class_pair[1])) for feature_class_pair in feature_class_array]
     mean_joint_entropy, _, min_joint_entropy, quartile1_joint_entropy, quartile2_joint_entropy, quartile3_joint_entropy, max_joint_entropy = profile_distribution(entropies)
     return (mean_joint_entropy, min_joint_entropy, quartile1_joint_entropy, quartile2_joint_entropy, quartile3_joint_entropy, max_joint_entropy)
 
@@ -38,3 +39,10 @@ def get_noise_signal_ratio(attribute_entropy, mutual_information):
     else:
         nsr = (attribute_entropy - mutual_information) / mutual_information
     return (nsr,)
+
+def translate_into_tuples(col1, col2):
+    col3 = []
+    for (k,v), (k2,v2) in zip(col1.items(),col2.items()):
+        t = (v,v2)
+        col3.append(t)
+    return pd.Series(col3);


### PR DESCRIPTION
Changed the parameter passed into the get_entropy function: it was formerly a series of strings that had been concatenated together from the separate columns. It is not a series of tuples of the values from the separate columns. Created the translate_into_tuples function in order to create the series of tuples from the columns to be evaluated.

#145 