### PR TITLE
added column_types argument to metafeature computation

### DIFF
--- a/test/data/compute_dataset_metafeatures.py
+++ b/test/data/compute_dataset_metafeatures.py
@@ -28,7 +28,7 @@ def compute_dataset_metafeatures():
         X, Y, column_types = read_dataset(dataset_metadata)
 
         start_time = time.time()
-        metafeatures = Metafeatures().compute(X=X, Y=Y, seed=CORRECTNESS_SEED)
+        metafeatures = Metafeatures().compute(X=X, Y=Y, column_types=column_types, seed=CORRECTNESS_SEED)
         run_time = time.time() - start_time
 
         if choice == "v":


### PR DESCRIPTION
compute_dataset_metafeatures and test_correctness were inconsistent because compute_dataset_metafeatures did not pass in the column_types from the metadata to the metafeature computation call. Adding in the column_types argument resolved the issue.
Closes #149 