### PR TITLE
updated dependency requirements to match d3m

### DIFF
--- a/openml_requirements.txt
+++ b/openml_requirements.txt
@@ -17,7 +17,7 @@ nbformat==4.4.0
 netaddr==0.7.19
 netifaces==0.10.7
 nose==1.3.7
-numpy==1.14.5
+numpy==1.15.2
 openml==0.7.0
 oslo.concurrency==3.27.0
 oslo.config==6.4.0
@@ -32,7 +32,7 @@ pytz==2018.5
 PyYAML==3.13
 requests==2.20.0
 rfc3986==1.1.0
-scikit-learn==0.19.2
+scikit-learn==0.20.0
 scipy==1.1.0
 six==1.11.0
 stevedore==1.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 arff2pandas==1.0.1
 jsonschema==2.6.0
 liac-arff==2.3
-numpy==1.14.5
+numpy==1.15.2
 pandas==0.23.4
 python-dateutil==2.7.3
 pytz==2018.5
-scikit-learn==0.19.2
+scikit-learn==0.20.0
 scipy==1.1.0
 six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ setup(
     download_url = 'https://github.com/byu-dml/metalearn/archive/{}.tar.gz'.format(__version__),
     keywords = ['metalearning', 'machine learning', 'metalearn'],
     install_requires = [
-        'numpy<=1.14.5'
-        'scikit-learn<=0.19.1',
+        'numpy<=1.15.2'
+        'scikit-learn<=0.20.0',
         'pandas<=0.23.4,>=0.21.0',
         'scipy<=1.1.0'
     ],


### PR DESCRIPTION
closes #146. All requirements should be up to date now. test_metafeatures and compare_with_openml both ran fine with the new requirements