### PR TITLE
makes it easier to compare updated mfs

### DIFF
--- a/tests/data/compute_dataset_metafeatures.py
+++ b/tests/data/compute_dataset_metafeatures.py
@@ -2,6 +2,7 @@ import json
 import os
 import time
 
+import numpy as np
 import pandas as pd
 
 from metalearn import Metafeatures
@@ -12,6 +13,15 @@ from .dataset import read_dataset
 def get_dataset_metafeatures_path(dataset_filename):
     dataset_name = dataset_filename.rsplit(".", 1)[0]
     return os.path.join(METAFEATURES_DIR, dataset_name+"_mf.json")
+
+
+def is_close(computed_value, known_value):
+    if type(known_value) is str:
+        correct = known_value == computed_value
+    else:
+        correct = np.array(np.isclose(known_value, computed_value, equal_nan=True)).all()
+    return correct
+
 
 def compute_dataset_metafeatures():
     metadata = json.load(open(METADATA_PATH, "r"))
@@ -28,11 +38,38 @@ def compute_dataset_metafeatures():
         X, Y, column_types = read_dataset(dataset_metadata)
 
         start_time = time.time()
-        metafeatures = Metafeatures().compute(X=X, Y=Y, column_types=column_types, seed=CORRECTNESS_SEED)
+        computed_mfs = Metafeatures().compute(X=X, Y=Y, column_types=column_types, seed=CORRECTNESS_SEED)
         run_time = time.time() - start_time
 
         if choice == "v":
-            print(json.dumps(metafeatures, sort_keys=True, indent=4))
+            known_mf_path = get_dataset_metafeatures_path(dataset_filename)
+            with open(known_mf_path, 'r') as fp:
+                known_mfs = json.load(fp)
+
+            new_mfs = {}
+            deleted_mfs = {}
+            updated_mfs = {}
+            same_mfs = {}
+            all_mf_names = set(list(computed_mfs.keys()) + list(known_mfs.keys()))
+            for mf in all_mf_names:
+                if mf not in known_mfs.keys():
+                    new_mfs[mf] = computed_mfs[mf]
+                elif mf not in computed_mfs.keys():
+                    deleted_mfs[mf] = known_mfs[mf]
+                elif is_close(computed_mfs[mf]['value'], known_mfs[mf]['value']):
+                    same_mfs[mf] = computed_mfs[mf]
+                else:
+                    updated_mfs[mf] = {'known': known_mfs[mf], 'computed': computed_mfs[mf]}
+
+            print('UNCHANGED METAFEATURES')
+            print(json.dumps(same_mfs, sort_keys=True, indent=4))
+            print('DELETED METAFEATURES')
+            print(json.dumps(deleted_mfs, sort_keys=True, indent=4))
+            print('NEW METAFEATURES')
+            print(json.dumps(new_mfs, sort_keys=True, indent=4))
+            print('UPDATED METAFEATURES')
+            print(json.dumps(updated_mfs, sort_keys=True, indent=4))
+
         print("Runtime: " + str(run_time))
 
         choice = None
@@ -40,4 +77,5 @@ def compute_dataset_metafeatures():
             choice = input(f"Update {dataset_filename} metafeatures? [(y)es, (n)o]: ")
         if choice == "y":
             mf_file_path = get_dataset_metafeatures_path(dataset_filename)
-            json.dump(metafeatures, open(mf_file_path, "w"), sort_keys=True, indent=4)
+            with open(mf_file_path, 'w') as fp:
+                json.dump(computed_mfs, fp, sort_keys=True, indent=4)


### PR DESCRIPTION
Running `compute_dataset_metafeatures.py` now shows a breakdown of new, deleted, unchanged, and updated metafeatures to more easily compare when making changes to metafeatures.

Sample output (not necessarily real values or metafeatures :) )

```
38_sick_train_data.csv [(y)es, (v)erbose, (n)o]: v
UNCHANGED METAFEATURES
{
    "StdevStdDevOfStringLengthOfTextFeatures": {
        "compute_time": 4.8173824325203896e-05,
        "value": NaN
    },
    "kNN1NErrRate": {
        "compute_time": 0.2978278868831694,
        "value": 0.09093279580094993
    },
    "kNN1NKappa": {
        "compute_time": 0.2978278868831694,
        "value": 0.16702041294319114
    }
}
DELETED METAFEATURES
{
    "Useless Metafeaure": {
        "compute_time": 0.001676646017585881,
        "value": 52.35637003353562
    }
}
NEW METAFEATURES
{
    "Someone's new metafeature": {
        "compute_time": 1,
        "value": "Cool"
    }
}
UPDATED METAFEATURES
{
    "StdevCardinalityOfCategoricalFeatures": {
        "computed": {
            "compute_time": 0.0033262099605053663,
            "value": 123423
        },
        "known": {
            "compute_time": 0.0033224879880435765,
            "value": 0.7101612523427369
        }
    }
}
Runtime: 0.8915457725524902
```