### PR TITLE
Perceptron metafeatures

### DIFF
--- a/metalearn/metafeatures/metafeatures.json
+++ b/metalearn/metafeatures/metafeatures.json
@@ -4277,7 +4277,7 @@
             ]
         },
         "StdevFullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4295,7 +4295,7 @@
             ]
         },
         "SkewFullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4313,7 +4313,7 @@
             ]
         },
         "KurtosisFullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4331,7 +4331,7 @@
             ]
         },
         "MinFullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4349,7 +4349,7 @@
             ]
         },
         "Quartile1FullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4367,7 +4367,7 @@
             ]
         },
         "Quartile2FullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4385,7 +4385,7 @@
             ]
         },
         "Quartile3FullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4403,7 +4403,7 @@
             ]
         },
         "MaxFullPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "FullPerceptron"
             },
@@ -4439,7 +4439,7 @@
             ]
         },
         "StdevOneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4457,7 +4457,7 @@
             ]
         },
         "SkewOneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4475,7 +4475,7 @@
             ]
         },
         "KurtosisOneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4493,7 +4493,7 @@
             ]
         },
         "MinOneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4511,7 +4511,7 @@
             ]
         },
         "Quartile1OneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4529,7 +4529,7 @@
             ]
         },
         "Quartile2OneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4547,7 +4547,7 @@
             ]
         },
         "Quartile3OneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },
@@ -4565,7 +4565,7 @@
             ]
         },
         "MaxOneTenthPerceptronWeights": {
-            "function": "get_perceptron_weights_sum",
+            "function": "get_perceptron_weights_dist",
             "arguments": {
                 "perceptron": "OneTenthPerceptron"
             },

--- a/metalearn/metafeatures/metafeatures.json
+++ b/metalearn/metafeatures/metafeatures.json
@@ -4906,6 +4906,674 @@
                 "MaxSqrtPerceptronWeights"
             ]
         },
+        "MeanFullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+
+        "StdevFullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+
+        "SkewFullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+
+        "KurtosisFullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+
+        "MinFullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+
+        "Quartile1FullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+        "Quartile2FullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+        "Quartile3FullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+        "MaxFullPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronBias",
+                "MeanFullPerceptronBias",
+                "StdevFullPerceptronBias",
+                "SkewFullPerceptronBias",
+                "KurtosisFullPerceptronBias",
+                "MinFullPerceptronBias",
+                "Quartile1FullPerceptronBias",
+                "Quartile2FullPerceptronBias",
+                "Quartile3FullPerceptronBias",
+                "MaxFullPerceptronBias"
+            ]
+        },
+        "MeanOneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+
+        "StdevOneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+
+        "SkewOneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+
+        "KurtosisOneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+
+        "MinOneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+
+        "Quartile1OneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+        "Quartile2OneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+        "Quartile3OneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+        "MaxOneTenthPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronBias",
+                "MeanOneTenthPerceptronBias",
+                "StdevOneTenthPerceptronBias",
+                "SkewOneTenthPerceptronBias",
+                "KurtosisOneTenthPerceptronBias",
+                "MinOneTenthPerceptronBias",
+                "Quartile1OneTenthPerceptronBias",
+                "Quartile2OneTenthPerceptronBias",
+                "Quartile3OneTenthPerceptronBias",
+                "MaxOneTenthPerceptronBias"
+            ]
+        },
+        "MeanOneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+
+        "StdevOneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+
+        "SkewOneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+
+        "KurtosisOneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+
+        "MinOneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+
+        "Quartile1OneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+        "Quartile2OneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+        "Quartile3OneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+        "MaxOneHalfPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronBias",
+                "MeanOneHalfPerceptronBias",
+                "StdevOneHalfPerceptronBias",
+                "SkewOneHalfPerceptronBias",
+                "KurtosisOneHalfPerceptronBias",
+                "MinOneHalfPerceptronBias",
+                "Quartile1OneHalfPerceptronBias",
+                "Quartile2OneHalfPerceptronBias",
+                "Quartile3OneHalfPerceptronBias",
+                "MaxOneHalfPerceptronBias"
+            ]
+        },
+        "MeanSqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+
+        "StdevSqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+
+        "SkewSqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+
+        "KurtosisSqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+
+        "MinSqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+
+        "Quartile1SqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+        "Quartile2SqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+        "Quartile3SqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
+        "MaxSqrtPerceptronBias": {
+            "function": "get_perceptron_bias_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronBias",
+                "MeanSqrtPerceptronBias",
+                "StdevSqrtPerceptronBias",
+                "SkewSqrtPerceptronBias",
+                "KurtosisSqrtPerceptronBias",
+                "MinSqrtPerceptronBias",
+                "Quartile1SqrtPerceptronBias",
+                "Quartile2SqrtPerceptronBias",
+                "Quartile3SqrtPerceptronBias",
+                "MaxSqrtPerceptronBias"
+            ]
+        },
         "FullPerceptronNIters": {
             "function": "get_perceptron_n_iters",
             "arguments": {

--- a/metalearn/metafeatures/metafeatures.json
+++ b/metalearn/metafeatures/metafeatures.json
@@ -176,6 +176,58 @@
             "returns": [
                 "TraversedDecisionTree"
             ]
+        },
+        "FullPerceptron": {
+            "function": "get_fitted_perceptron",
+            "arguments": {
+                "X": "XPreprocessed",
+                "Y": "YSample",
+                "seed": 10,
+                "n_classes": "NumberOfClasses",
+                "frac": "all"
+            },
+            "returns": [
+                "FullPerceptron"
+            ]
+        },
+        "OneTenthPerceptron": {
+            "function": "get_fitted_perceptron",
+            "arguments": {
+                "X": "XPreprocessed",
+                "Y": "YSample",
+                "seed": 11,
+                "n_classes": "NumberOfClasses",
+                "frac": "tenth"
+            },
+            "returns": [
+                "OneTenthPerceptron"
+            ]
+        },
+        "OneHalfPerceptron": {
+            "function": "get_fitted_perceptron",
+            "arguments": {
+                "X": "XPreprocessed",
+                "Y": "YSample",
+                "seed": 12,
+                "n_classes": "NumberOfClasses",
+                "frac": "half"
+            },
+            "returns": [
+                "OneHalfPerceptron"
+            ]
+        },
+        "SqrtPerceptron": {
+            "function": "get_fitted_perceptron",
+            "arguments": {
+                "X": "XPreprocessed",
+                "Y": "YSample",
+                "seed": 13,
+                "n_classes": "NumberOfClasses",
+                "frac": "sqrt"
+            },
+            "returns": [
+                "SqrtPerceptron"
+            ]
         }
     },
     "metafeatures": {
@@ -4168,6 +4220,726 @@
                 "NumberOfTokensContainingNumericChar",
                 "RatioOfDistinctTokens",
                 "RatioOfTokensContainingNumericChar"
+            ]
+        },
+        "FullPerceptronWeightsSum": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeightsSum"
+            ]
+        },
+        "OneTenthPerceptronWeightsSum": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeightsSum"
+            ]
+        },
+        "OneHalfPerceptronWeightsSum": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeightsSum"
+            ]
+        },
+        "SqrtPerceptronWeightsSum": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeightsSum"
+            ]
+        },
+        "MeanFullPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "StdevFullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "SkewFullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "KurtosisFullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "MinFullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "Quartile1FullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "Quartile2FullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "Quartile3FullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "MaxFullPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronWeights",
+                "MeanFullPerceptronWeights",
+                "StdevFullPerceptronWeights",
+                "SkewFullPerceptronWeights",
+                "KurtosisFullPerceptronWeights",
+                "MinFullPerceptronWeights",
+                "Quartile1FullPerceptronWeights",
+                "Quartile2FullPerceptronWeights",
+                "Quartile3FullPerceptronWeights",
+                "MaxFullPerceptronWeights"
+            ]
+        },
+        "MeanOneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "StdevOneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "SkewOneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "KurtosisOneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "MinOneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "Quartile1OneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "Quartile2OneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "Quartile3OneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "MaxOneTenthPerceptronWeights": {
+            "function": "get_perceptron_weights_sum",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronWeights",
+                "MeanOneTenthPerceptronWeights",
+                "StdevOneTenthPerceptronWeights",
+                "SkewOneTenthPerceptronWeights",
+                "KurtosisOneTenthPerceptronWeights",
+                "MinOneTenthPerceptronWeights",
+                "Quartile1OneTenthPerceptronWeights",
+                "Quartile2OneTenthPerceptronWeights",
+                "Quartile3OneTenthPerceptronWeights",
+                "MaxOneTenthPerceptronWeights"
+            ]
+        },
+        "MeanOneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "StdevOneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "SkewOneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "KurtosisOneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "MinOneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "Quartile1OneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "Quartile2OneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "Quartile3OneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "MaxOneHalfPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronWeights",
+                "MeanOneHalfPerceptronWeights",
+                "StdevOneHalfPerceptronWeights",
+                "SkewOneHalfPerceptronWeights",
+                "KurtosisOneHalfPerceptronWeights",
+                "MinOneHalfPerceptronWeights",
+                "Quartile1OneHalfPerceptronWeights",
+                "Quartile2OneHalfPerceptronWeights",
+                "Quartile3OneHalfPerceptronWeights",
+                "MaxOneHalfPerceptronWeights"
+            ]
+        },
+        "MeanSqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "StdevSqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "SkewSqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "KurtosisSqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "MinSqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "Quartile1SqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "Quartile2SqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "Quartile3SqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "MaxSqrtPerceptronWeights": {
+            "function": "get_perceptron_weights_dist",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronWeights",
+                "MeanSqrtPerceptronWeights",
+                "StdevSqrtPerceptronWeights",
+                "SkewSqrtPerceptronWeights",
+                "KurtosisSqrtPerceptronWeights",
+                "MinSqrtPerceptronWeights",
+                "Quartile1SqrtPerceptronWeights",
+                "Quartile2SqrtPerceptronWeights",
+                "Quartile3SqrtPerceptronWeights",
+                "MaxSqrtPerceptronWeights"
+            ]
+        },
+        "FullPerceptronNIters": {
+            "function": "get_perceptron_n_iters",
+            "arguments": {
+                "perceptron": "FullPerceptron"
+            },
+            "returns": [
+                "FullPerceptronNIters"
+            ]
+        },
+        "OneTenthPerceptronNIters": {
+            "function": "get_perceptron_n_iters",
+            "arguments": {
+                "perceptron": "OneTenthPerceptron"
+            },
+            "returns": [
+                "OneTenthPerceptronNIters"
+            ]
+        },
+        "OneHalfPerceptronNIters": {
+            "function": "get_perceptron_n_iters",
+            "arguments": {
+                "perceptron": "OneHalfPerceptron"
+            },
+            "returns": [
+                "OneHalfPerceptronNIters"
+            ]
+        },
+        "SqrtPerceptronNIters": {
+            "function": "get_perceptron_n_iters",
+            "arguments": {
+                "perceptron": "SqrtPerceptron"
+            },
+            "returns": [
+                "SqrtPerceptronNIters"
             ]
         }
     }

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -19,6 +19,7 @@ from .information_theoretic_metafeatures import *
 from .landmarking_metafeatures import *
 from .decision_tree_metafeatures import *
 from .text_metafeatures import *
+from .perceptron_metafeatures import *
 
 
 class Metafeatures(object):

--- a/metalearn/metafeatures/perceptron_metafeatures.py
+++ b/metalearn/metafeatures/perceptron_metafeatures.py
@@ -7,8 +7,8 @@ from metalearn.metafeatures.common_operations import profile_distribution
 def get_fitted_perceptron(X, Y, seed, n_classes, frac='all'):
     class_fraction = n_classes/len(X)
 
-    if len(X) < n_classes * 2:
-        raise ValueError(f'The number of instances in X must be at least 2 * n_classes')
+    # if len(X) < n_classes * 2:
+    #     raise ValueError(f'The number of instances in X must be at least 2 * n_classes')
 
     if frac == 'all':
         frac = class_fraction

--- a/metalearn/metafeatures/perceptron_metafeatures.py
+++ b/metalearn/metafeatures/perceptron_metafeatures.py
@@ -39,5 +39,11 @@ def get_perceptron_weights_dist(perceptron):
     return profile_distribution(weights)
 
 
+def get_perceptron_bias_dist(perceptron):
+    intercepts = perceptron.intercept_
+    return profile_distribution(intercepts)
+
+
 def get_perceptron_n_iters(perceptron):
-    return perceptron.n_iter_,
+    n_iter = perceptron.n_iter_
+    return n_iter,

--- a/metalearn/metafeatures/perceptron_metafeatures.py
+++ b/metalearn/metafeatures/perceptron_metafeatures.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from sklearn.linear_model import Perceptron
 
 from metalearn.metafeatures.common_operations import profile_distribution
@@ -7,22 +8,23 @@ from metalearn.metafeatures.common_operations import profile_distribution
 def get_fitted_perceptron(X, Y, seed, n_classes, frac='all'):
     class_fraction = n_classes/len(X)
 
-    # if len(X) < n_classes * 2:
-    #     raise ValueError(f'The number of instances in X must be at least 2 * n_classes')
-
     if frac == 'all':
         frac = class_fraction
     elif frac == 'tenth':
-        frac = min(max(0.9, class_fraction), 1-class_fraction)
+        frac = min(max(0.9, class_fraction), 1 - class_fraction)
     elif frac == 'half':
-        frac = min(max(0.5, class_fraction), 1-class_fraction)
+        frac = min(max(0.5, class_fraction), 1 - class_fraction)
     elif frac == 'sqrt':
-        frac = min(max(1 - (np.sqrt(len(X)) / len(X)), class_fraction), 1-class_fraction)
-    else:
-        raise ValueError(f'{frac} is not a valid option. Must be one of ["all", "tenth", "half", "sqrt"]')
+        frac = min(max(1 - (np.sqrt(len(X)) / len(X)), class_fraction), 1 - class_fraction)
 
     cls = Perceptron(random_state=seed, validation_fraction=frac, early_stopping=True, max_iter=1000, tol=1e-3)
-    cls.fit(X, Y)
+
+    if n_classes == 1:
+        cls.coef_ = np.array([0.0 for i in range(X.shape[1])])
+        cls.intercept_ = np.array([0])
+        cls.n_iter_ = 0
+    else:
+        cls.fit(X, Y)
 
     return cls,
 

--- a/metalearn/metafeatures/perceptron_metafeatures.py
+++ b/metalearn/metafeatures/perceptron_metafeatures.py
@@ -1,0 +1,41 @@
+import numpy as np
+from sklearn.linear_model import Perceptron
+
+from metalearn.metafeatures.common_operations import profile_distribution
+
+
+def get_fitted_perceptron(X, Y, seed, n_classes, frac='all'):
+    class_fraction = n_classes/len(X)
+
+    if len(X) < n_classes * 2:
+        raise ValueError(f'The number of instances in X must be at least 2 * n_classes')
+
+    if frac == 'all':
+        frac = class_fraction
+    elif frac == 'tenth':
+        frac = min(max(0.9, class_fraction), 1-class_fraction)
+    elif frac == 'half':
+        frac = min(max(0.5, class_fraction), 1-class_fraction)
+    elif frac == 'sqrt':
+        frac = min(max(1 - (np.sqrt(len(X)) / len(X)), class_fraction), 1-class_fraction)
+    else:
+        raise ValueError(f'{frac} is not a valid option. Must be one of ["all", "tenth", "half", "sqrt"]')
+
+    cls = Perceptron(random_state=seed, validation_fraction=frac, early_stopping=True, max_iter=1000, tol=1e-3)
+    cls.fit(X, Y)
+
+    return cls,
+
+
+def get_perceptron_weights_sum(perceptron):
+    weights_sum = np.sum(perceptron.coef_)
+    return weights_sum,
+
+
+def get_perceptron_weights_dist(perceptron):
+    weights = perceptron.coef_.flatten()
+    return profile_distribution(weights)
+
+
+def get_perceptron_n_iters(perceptron):
+    return perceptron.n_iter_,

--- a/tests/data/dataset_metafeatures/38_sick_train_data_mf.json
+++ b/tests/data/dataset_metafeatures/38_sick_train_data_mf.json
@@ -1,926 +1,1102 @@
 {
     "CategoricalNoiseToSignalRatio": {
-        "compute_time": 0.10639627503405791,
+        "compute_time": 0.13630880694836378,
         "value": 65.12375165878576
     },
     "ClassEntropy": {
-        "compute_time": 0.0016181730170501396,
+        "compute_time": 0.0016491240821778774,
         "value": 0.2303678505246139
     },
     "DecisionStumpErrRate": {
-        "compute_time": 0.05637974603450857,
+        "compute_time": 0.055732094682753086,
         "value": 0.0530205974425042
     },
     "DecisionStumpKappa": {
-        "compute_time": 0.05637974603450857,
+        "compute_time": 0.055732094682753086,
         "value": 0.6460807839667586
     },
     "DecisionTreeHeight": {
-        "compute_time": 0.039231870032381266,
+        "compute_time": 0.03843450476415455,
         "value": 11
     },
     "DecisionTreeLeafCount": {
-        "compute_time": 0.039231870032381266,
+        "compute_time": 0.03843450476415455,
         "value": 49
     },
     "DecisionTreeNodeCount": {
-        "compute_time": 0.039231870032381266,
+        "compute_time": 0.03843450476415455,
         "value": 97
     },
     "DecisionTreeWidth": {
-        "compute_time": 0.039326284037088044,
+        "compute_time": 0.03852409706450999,
         "value": 9
     },
     "Dimensionality": {
-        "compute_time": 4.1207007598131895e-05,
+        "compute_time": 4.419195465743542e-05,
         "value": 0.0076882290562036056
     },
     "EquivalentNumberOfCategoricalFeatures": {
-        "compute_time": 0.0810160680412082,
+        "compute_time": 0.0707257913891226,
         "value": 64.97682682412889
     },
     "EquivalentNumberOfNumericFeatures": {
-        "compute_time": 0.11181286803912371,
+        "compute_time": 0.11437551281414926,
         "value": 8.265561221791359
     },
+    "FullPerceptronNIters": {
+        "compute_time": 0.03920784080401063,
+        "value": 6
+    },
+    "FullPerceptronWeightsSum": {
+        "compute_time": 0.03921809163875878,
+        "value": -2775.568999999999
+    },
     "KurtosisCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 10.626941000939418
     },
     "KurtosisCardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": -1.5824634006168445
     },
     "KurtosisCategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 3.6459237447298536
     },
     "KurtosisCategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 3.2709710235309224
     },
     "KurtosisCategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 14.080033213321688
     },
     "KurtosisClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": -2.0
     },
     "KurtosisDecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 10.617333960472148
     },
     "KurtosisDecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": -0.20597828128078532
     },
     "KurtosisDecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": -1.1570111417931213
     },
+    "KurtosisFullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": 16.40443581766465
+    },
     "KurtosisKurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 1.0285691141266575
     },
     "KurtosisKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "KurtosisMeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": -1.6406633903613828
     },
     "KurtosisMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "KurtosisNumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 0.25957571575898
     },
     "KurtosisNumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 0.18662301318798447
     },
     "KurtosisNumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.7111184356200178
     },
+    "KurtosisOneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": 8.202661125745076
+    },
+    "KurtosisOneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": 16.449254902960103
+    },
     "KurtosisSkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 1.1767947825290799
     },
     "KurtosisSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "KurtosisSqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": 23.581200934652315
+    },
     "KurtosisStdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": -1.5096852202508921
     },
     "KurtosisStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "LinearDiscriminantAnalysisErrRate": {
-        "compute_time": 0.09895071103528608,
+        "compute_time": 0.09883636771701276,
         "value": 0.050901392889222574
     },
     "LinearDiscriminantAnalysisKappa": {
-        "compute_time": 0.09895071103528608,
+        "compute_time": 0.09883636771701276,
         "value": 0.41518335844457105
     },
     "MajorityClassSize": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 3541
     },
     "MaxCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 5.0
     },
     "MaxCardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 288.0
     },
     "MaxCategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 1.0540619253604604
     },
     "MaxCategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 1.2427930071894404
     },
     "MaxCategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 0.04163676869563335
     },
     "MaxClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.9387592788971368
     },
     "MaxDecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 49.0
     },
     "MaxDecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 10.0
     },
     "MaxDecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 22.0
     },
+    "MaxFullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": 550.0
+    },
     "MaxKurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 238.18146237806315
     },
     "MaxKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "MaxMeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 110.4696486566283
     },
     "MaxMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "MaxNumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 1.7001812503765323
     },
     "MaxNumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 1.9127090565977578
     },
     "MaxNumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.10645678195030889
     },
+    "MaxOneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": 250.0
+    },
+    "MaxOneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": 351.0
+    },
     "MaxSkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 13.882652755041768
     },
     "MaxSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "MaxSqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": 165.0
+    },
     "MaxStdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 35.60424760764098
     },
     "MaxStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "MeanCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 2.1363636363636362
     },
     "MeanCardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 179.33333333333334
     },
     "MeanCategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 0.2344341403357237
     },
     "MeanCategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 0.4613654485629755
     },
     "MeanCategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 0.003545384743827898
     },
     "MeanClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.5
     },
     "MeanDecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 5.705882352941177
     },
     "MeanDecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 6.26530612244898
     },
     "MeanDecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 8.818181818181818
     },
+    "MeanFullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": -53.3763269230769
+    },
     "MeanKurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 51.413135065510026
     },
     "MeanKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "MeanMeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 46.436689696411385
     },
     "MeanMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "MeanNumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 1.240228736551128
     },
     "MeanNumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 1.4577611891821942
     },
     "MeanNumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.027870805664988743
     },
+    "MeanOneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": -24.812192307692296
+    },
+    "MeanOneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": -15.60855769230769
+    },
     "MeanSkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 3.5691918824691036
     },
     "MeanSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "MeanSqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": -5.601249999999999
+    },
     "MeanStdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 19.053877588965566
     },
     "MeanStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "MinCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 1.0
     },
     "MinCardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 70.0
     },
     "MinCategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 0.0
     },
     "MinCategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 0.2303678505246139
     },
     "MinCategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": -1.6653345369377348e-15
     },
     "MinClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.0612407211028632
     },
     "MinDecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 1.0
     },
     "MinDecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 4.0
     },
     "MinDecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 1.0
     },
+    "MinFullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": -1187.7399999999986
+    },
     "MinKurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 4.073471498748891
     },
     "MinKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "MinMeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 0.9949997045790251
     },
     "MinMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "MinNumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 0.14521170237536474
     },
     "MinNumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 0.39093470087095644
     },
     "MinNumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.0008582987317293472
     },
+    "MinOneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": -568.4999999999999
+    },
+    "MinOneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": -435.0
+    },
     "MinSkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 1.2326742385072778
     },
     "MinSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "MinSqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": -279.0
+    },
     "MinStdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 0.1954572751132885
     },
     "MinStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "MinorityClassSize": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 231
     },
     "NaiveBayesErrRate": {
-        "compute_time": 0.05943656704039313,
+        "compute_time": 0.059335523983463645,
         "value": 0.6781856595244019
     },
     "NaiveBayesKappa": {
-        "compute_time": 0.05943656704039313,
+        "compute_time": 0.059335523983463645,
         "value": 0.039699494487290043
     },
     "NumberOfCategoricalFeatures": {
-        "compute_time": 1.9931001588702202e-05,
+        "compute_time": 2.160598523914814e-05,
         "value": 22
     },
     "NumberOfClasses": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 2
     },
     "NumberOfDistinctTokens": {
-        "compute_time": 0.00022466000518761575,
+        "compute_time": 0.000236984109506011,
         "value": 0
     },
     "NumberOfFeatures": {
-        "compute_time": 1.9931001588702202e-05,
+        "compute_time": 2.160598523914814e-05,
         "value": 29
     },
     "NumberOfFeaturesWithMissingValues": {
-        "compute_time": 0.008072049007751048,
+        "compute_time": 0.0077187600545585155,
         "value": 8
     },
     "NumberOfInstances": {
-        "compute_time": 1.9931001588702202e-05,
+        "compute_time": 2.160598523914814e-05,
         "value": 3772
     },
     "NumberOfInstancesWithMissingValues": {
-        "compute_time": 0.008072049007751048,
+        "compute_time": 0.0077187600545585155,
         "value": 3772
     },
     "NumberOfMissingValues": {
-        "compute_time": 0.008072049007751048,
+        "compute_time": 0.0077187600545585155,
         "value": 6064
     },
     "NumberOfNumericFeatures": {
-        "compute_time": 1.9931001588702202e-05,
+        "compute_time": 2.160598523914814e-05,
         "value": 7
     },
     "NumberOfTokens": {
-        "compute_time": 0.00022466000518761575,
+        "compute_time": 0.000236984109506011,
         "value": 0
     },
     "NumberOfTokensContainingNumericChar": {
-        "compute_time": 0.00022466000518761575,
+        "compute_time": 0.000236984109506011,
         "value": 0
     },
     "NumericNoiseToSignalRatio": {
-        "compute_time": 0.1318673100322485,
+        "compute_time": 0.13274331064894795,
         "value": 43.499206497970064
     },
+    "OneHalfPerceptronNIters": {
+        "compute_time": 0.038686589105054736,
+        "value": 6
+    },
+    "OneHalfPerceptronWeightsSum": {
+        "compute_time": 0.038698060903698206,
+        "value": -1290.2339999999995
+    },
+    "OneTenthPerceptronNIters": {
+        "compute_time": 0.037826212821528316,
+        "value": 6
+    },
+    "OneTenthPerceptronWeightsSum": {
+        "compute_time": 0.03783675283193588,
+        "value": -811.6449999999999
+    },
     "PredDet": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 8.398206098130474e+47
     },
     "PredEigen1": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 2076.940458333572
     },
     "PredEigen2": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 584.6940837111429
     },
     "PredEigen3": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 416.0684363789902
     },
     "PredPCA1": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 0.6131782342417007
     },
     "PredPCA2": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 0.17262010780474016
     },
     "PredPCA3": {
-        "compute_time": 0.07142707602179144,
+        "compute_time": 0.08503678883425891,
         "value": 0.12283650603410787
     },
     "Quartile1CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 2.0
     },
     "Quartile1CardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 107.25
     },
     "Quartile1CategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 0.07132665652246652
     },
     "Quartile1CategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 0.3014425793394888
     },
     "Quartile1CategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 0.000401382222092676
     },
     "Quartile1ClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.2806203605514316
     },
     "Quartile1DecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 1.0
     },
     "Quartile1DecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 5.0
     },
     "Quartile1DecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 3.0
     },
+    "Quartile1FullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": -66.25
+    },
     "Quartile1KurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 6.9324686702015095
     },
     "Quartile1KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "Quartile1MeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 2.7818163973111814
     },
     "Quartile1MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "Quartile1NumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 1.1599826109278069
     },
     "Quartile1NumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 1.3652560566996312
     },
     "Quartile1NumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.005350531172490503
     },
+    "Quartile1OneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": -18.0
+    },
+    "Quartile1OneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": -14.25
+    },
     "Quartile1SkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 1.2871359905719386
     },
     "Quartile1SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "Quartile1SqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": -2.0
+    },
     "Quartile1StdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 5.641815238818264
     },
     "Quartile1StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "Quartile2CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 2.0
     },
     "Quartile2CardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 191.0
     },
     "Quartile2CategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 0.17978494759170108
     },
     "Quartile2CategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 0.40854057385576326
     },
     "Quartile2CategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 0.0008944661141944213
     },
     "Quartile2ClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.5
     },
     "Quartile2DecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 2.0
     },
     "Quartile2DecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 6.0
     },
     "Quartile2DecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 6.0
     },
+    "Quartile2FullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": -31.0
+    },
     "Quartile2KurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 8.871303806575874
     },
     "Quartile2KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "Quartile2MeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 28.41132258295654
     },
     "Quartile2MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "Quartile2NumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 1.47782513171791
     },
     "Quartile2NumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 1.6768594976548352
     },
     "Quartile2NumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.013027973551840908
     },
+    "Quartile2OneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": -3.5
+    },
+    "Quartile2OneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": -10.0
+    },
     "Quartile2SkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 1.5381528946216996
     },
     "Quartile2SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "Quartile2SqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": -1.0
+    },
     "Quartile2StdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 22.30321439330161
     },
     "Quartile2StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "Quartile3CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 2.0
     },
     "Quartile3CardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 240.25
     },
     "Quartile3CategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 0.32727219276174513
     },
     "Quartile3CategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 0.5549217204785228
     },
     "Quartile3CategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 0.0021054152441979074
     },
     "Quartile3ClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.7193796394485685
     },
     "Quartile3DecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 4.0
     },
     "Quartile3DecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 7.0
     },
     "Quartile3DecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 15.0
     },
+    "Quartile3FullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": 2.25
+    },
     "Quartile3KurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 33.86413491040868
     },
     "Quartile3KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "Quartile3MeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 94.17347838267801
     },
     "Quartile3MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "Quartile3NumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 1.5591768572704363
     },
     "Quartile3NumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 1.7900769788638717
     },
     "Quartile3NumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.026553810256589254
     },
+    "Quartile3OneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": 6.0
+    },
+    "Quartile3OneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": -1.75
+    },
     "Quartile3SkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 1.8995793407555395
     },
     "Quartile3SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "Quartile3SqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": 0.0
+    },
     "Quartile3StdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 30.947640856159467
     },
     "Quartile3StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "RandomTreeDepth1ErrRate": {
-        "compute_time": 0.055062069033738226,
+        "compute_time": 0.05467251571826637,
         "value": 0.061240597751753945
     },
     "RandomTreeDepth1Kappa": {
-        "compute_time": 0.055062069033738226,
+        "compute_time": 0.05467251571826637,
         "value": 0.0
     },
     "RandomTreeDepth2ErrRate": {
-        "compute_time": 0.05544865602860227,
+        "compute_time": 0.055194378830492496,
         "value": 0.061240597751753945
     },
     "RandomTreeDepth2Kappa": {
-        "compute_time": 0.05544865602860227,
+        "compute_time": 0.055194378830492496,
         "value": 0.0
     },
     "RandomTreeDepth3ErrRate": {
-        "compute_time": 0.05578341003274545,
+        "compute_time": 0.055694324895739555,
         "value": 0.046121234356528484
     },
     "RandomTreeDepth3Kappa": {
-        "compute_time": 0.05578341003274545,
+        "compute_time": 0.055694324895739555,
         "value": 0.3551191328085659
     },
     "RatioOfCategoricalFeatures": {
-        "compute_time": 1.9931001588702202e-05,
+        "compute_time": 2.160598523914814e-05,
         "value": 0.7586206896551724
     },
     "RatioOfDistinctTokens": {
-        "compute_time": 0.00022466000518761575,
+        "compute_time": 0.000236984109506011,
         "value": 0
     },
     "RatioOfFeaturesWithMissingValues": {
-        "compute_time": 0.008072049007751048,
+        "compute_time": 0.0077187600545585155,
         "value": 0.27586206896551724
     },
     "RatioOfInstancesWithMissingValues": {
-        "compute_time": 0.008072049007751048,
+        "compute_time": 0.0077187600545585155,
         "value": 1.0
     },
     "RatioOfMissingValues": {
-        "compute_time": 0.008072049007751048,
+        "compute_time": 0.0077187600545585155,
         "value": 0.05543569678575346
     },
     "RatioOfNumericFeatures": {
-        "compute_time": 1.9931001588702202e-05,
+        "compute_time": 2.160598523914814e-05,
         "value": 0.2413793103448276
     },
     "RatioOfTokensContainingNumericChar": {
-        "compute_time": 0.00022466000518761575,
+        "compute_time": 0.000236984109506011,
         "value": 0
     },
     "SkewCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 3.077104198750258
     },
     "SkewCardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": -0.08243378475608776
     },
     "SkewCategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 1.8559533279845721
     },
     "SkewCategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 1.7769649555998623
     },
     "SkewCategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 3.875490250344927
     },
     "SkewClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 2.4645212079004602e-16
     },
     "SkewDecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 3.451450787668906
     },
     "SkewDecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 0.5980222656789738
     },
     "SkewDecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 0.5765667421352726
     },
+    "SkewFullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": -2.904979202015009
+    },
     "SkewKurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 1.7025904731327763
     },
     "SkewKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "SkewMeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 0.3777827539698624
     },
     "SkewMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "SkewNumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": -1.3148700862947547
     },
     "SkewNumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": -1.268339377641566
     },
     "SkewNumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 1.5338906741146343
     },
+    "SkewOneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": -2.410910461022147
+    },
+    "SkewOneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": -0.9867800143145794
+    },
     "SkewSkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 1.776083146506227
     },
     "SkewSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "SkewSqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": -3.0316835648178238
+    },
     "SkewStdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": -0.31628077149128647
     },
     "SkewStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
+    "SqrtPerceptronNIters": {
+        "compute_time": 0.03770280280150473,
+        "value": 6
+    },
+    "SqrtPerceptronWeightsSum": {
+        "compute_time": 0.03771341987885535,
+        "value": -291.265
+    },
     "StdevCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0033224879880435765,
+        "compute_time": 0.0035173408687114716,
         "value": 0.7101612523427369
     },
     "StdevCardinalityOfNumericFeatures": {
-        "compute_time": 0.0013872389972675592,
+        "compute_time": 0.0014439760707318783,
         "value": 88.44810154359824
     },
     "StdevCategoricalAttributeEntropy": {
-        "compute_time": 0.026999106019502506,
+        "compute_time": 0.06723319087177515,
         "value": 0.24659802585010002
     },
     "StdevCategoricalJointEntropy": {
-        "compute_time": 0.0739495230227476,
+        "compute_time": 0.06400116207078099,
         "value": 0.23956528678973543
     },
     "StdevCategoricalMutualInformation": {
-        "compute_time": 0.07939626401639543,
+        "compute_time": 0.06907475017942488,
         "value": 0.00886031490652107
     },
     "StdevClassProbability": {
-        "compute_time": 0.0012301289971219376,
+        "compute_time": 0.001252528978511691,
         "value": 0.6204993228333702
     },
     "StdevDecisionTreeAttribute": {
-        "compute_time": 0.039824964027502574,
+        "compute_time": 0.03904539393261075,
         "value": 11.444238211226388
     },
     "StdevDecisionTreeBranchLength": {
-        "compute_time": 0.039884808036731556,
+        "compute_time": 0.039101457921788096,
         "value": 1.551551779725726
     },
     "StdevDecisionTreeLevelSize": {
-        "compute_time": 0.039929140024469234,
+        "compute_time": 0.03914717095904052,
         "value": 7.386720271110607
     },
+    "StdevFullPerceptronWeights": {
+        "compute_time": 0.03977922978810966,
+        "value": 208.9336462921427
+    },
     "StdevKurtosisOfNumericFeatures": {
-        "compute_time": 0.0018031450163107365,
+        "compute_time": 0.001857818104326725,
         "value": 92.56654555918352
     },
     "StdevKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.747702041640878e-05,
+        "compute_time": 4.772399552166462e-05,
         "value": NaN
     },
     "StdevMeansOfNumericFeatures": {
-        "compute_time": 0.001676646017585881,
+        "compute_time": 0.0017811150755733252,
         "value": 52.35637003353562
     },
     "StdevMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.871402052231133e-05,
+        "compute_time": 4.9187103286385536e-05,
         "value": NaN
     },
     "StdevNumericAttributeEntropy": {
-        "compute_time": 0.021672753005987033,
+        "compute_time": 0.020017019007354975,
         "value": 0.5768649195847191
     },
     "StdevNumericJointEntropy": {
-        "compute_time": 0.02701053602504544,
+        "compute_time": 0.02730743191204965,
         "value": 0.56604507540674
     },
     "StdevNumericMutualInformation": {
-        "compute_time": 0.1101939080253942,
+        "compute_time": 0.11272568674758077,
         "value": 0.039885364866017826
     },
+    "StdevOneHalfPerceptronWeights": {
+        "compute_time": 0.039217038080096245,
+        "value": 125.24182377806707
+    },
+    "StdevOneTenthPerceptronWeights": {
+        "compute_time": 0.038355675991624594,
+        "value": 84.65172899532865
+    },
     "StdevSkewnessOfNumericFeatures": {
-        "compute_time": 0.0017805700190365314,
+        "compute_time": 0.0018326959107071161,
         "value": 5.060654984907634
     },
     "StdevSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.742601595353335e-05,
+        "compute_time": 4.773004911839962e-05,
         "value": NaN
     },
+    "StdevSqrtPerceptronWeights": {
+        "compute_time": 0.038225420052185655,
+        "value": 46.94289723544812
+    },
     "StdevStdDevOfNumericFeatures": {
-        "compute_time": 0.0018315060005988926,
+        "compute_time": 0.001887504942715168,
         "value": 15.425433204049687
     },
     "StdevStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.774001718033105e-05,
+        "compute_time": 4.812306724488735e-05,
         "value": NaN
     },
     "kNN1NErrRate": {
-        "compute_time": 0.3015885370259639,
+        "compute_time": 0.30677097267471254,
         "value": 0.09093279580094993
     },
     "kNN1NKappa": {
-        "compute_time": 0.3015885370259639,
+        "compute_time": 0.30677097267471254,
         "value": 0.16702041294319114
     }
 }

--- a/tests/data/dataset_metafeatures/38_sick_train_data_mf.json
+++ b/tests/data/dataset_metafeatures/38_sick_train_data_mf.json
@@ -1,1102 +1,1246 @@
 {
     "CategoricalNoiseToSignalRatio": {
-        "compute_time": 0.13630880694836378,
+        "compute_time": 0.11296505620703101,
         "value": 65.12375165878576
     },
     "ClassEntropy": {
-        "compute_time": 0.0016491240821778774,
+        "compute_time": 0.0015774690546095371,
         "value": 0.2303678505246139
     },
     "DecisionStumpErrRate": {
-        "compute_time": 0.055732094682753086,
+        "compute_time": 0.05520381103269756,
         "value": 0.0530205974425042
     },
     "DecisionStumpKappa": {
-        "compute_time": 0.055732094682753086,
+        "compute_time": 0.05520381103269756,
         "value": 0.6460807839667586
     },
     "DecisionTreeHeight": {
-        "compute_time": 0.03843450476415455,
+        "compute_time": 0.03804580285213888,
         "value": 11
     },
     "DecisionTreeLeafCount": {
-        "compute_time": 0.03843450476415455,
+        "compute_time": 0.03804580285213888,
         "value": 49
     },
     "DecisionTreeNodeCount": {
-        "compute_time": 0.03843450476415455,
+        "compute_time": 0.03804580285213888,
         "value": 97
     },
     "DecisionTreeWidth": {
-        "compute_time": 0.03852409706450999,
+        "compute_time": 0.038136901101097465,
         "value": 9
     },
     "Dimensionality": {
-        "compute_time": 4.419195465743542e-05,
+        "compute_time": 4.2926520109176636e-05,
         "value": 0.0076882290562036056
     },
     "EquivalentNumberOfCategoricalFeatures": {
-        "compute_time": 0.0707257913891226,
+        "compute_time": 0.07093218015506864,
         "value": 64.97682682412889
     },
     "EquivalentNumberOfNumericFeatures": {
-        "compute_time": 0.11437551281414926,
+        "compute_time": 0.11474013584665954,
         "value": 8.265561221791359
     },
     "FullPerceptronNIters": {
-        "compute_time": 0.03920784080401063,
+        "compute_time": 0.038425146136432886,
         "value": 6
     },
     "FullPerceptronWeightsSum": {
-        "compute_time": 0.03921809163875878,
+        "compute_time": 0.038433213951066136,
         "value": -2775.568999999999
     },
     "KurtosisCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 10.626941000939418
     },
     "KurtosisCardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": -1.5824634006168445
     },
     "KurtosisCategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 3.6459237447298536
     },
     "KurtosisCategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 3.2709710235309224
     },
     "KurtosisCategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 14.080033213321688
     },
     "KurtosisClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": -2.0
     },
     "KurtosisDecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 10.617333960472148
     },
     "KurtosisDecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": -0.20597828128078532
     },
     "KurtosisDecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": -1.1570111417931213
     },
+    "KurtosisFullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -3.0
+    },
     "KurtosisFullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": 16.40443581766465
     },
     "KurtosisKurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 1.0285691141266575
     },
     "KurtosisKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "KurtosisMeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": -1.6406633903613828
     },
     "KurtosisMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "KurtosisNumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 0.25957571575898
     },
     "KurtosisNumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 0.18662301318798447
     },
     "KurtosisNumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.7111184356200178
     },
+    "KurtosisOneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -3.0
+    },
     "KurtosisOneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": 8.202661125745076
     },
+    "KurtosisOneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -3.0
+    },
     "KurtosisOneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": 16.449254902960103
     },
     "KurtosisSkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 1.1767947825290799
     },
     "KurtosisSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "KurtosisSqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -3.0
+    },
     "KurtosisSqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": 23.581200934652315
     },
     "KurtosisStdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": -1.5096852202508921
     },
     "KurtosisStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "LinearDiscriminantAnalysisErrRate": {
-        "compute_time": 0.09883636771701276,
+        "compute_time": 0.09643691079691052,
         "value": 0.050901392889222574
     },
     "LinearDiscriminantAnalysisKappa": {
-        "compute_time": 0.09883636771701276,
+        "compute_time": 0.09643691079691052,
         "value": 0.41518335844457105
     },
     "MajorityClassSize": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 3541
     },
     "MaxCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 5.0
     },
     "MaxCardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 288.0
     },
     "MaxCategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 1.0540619253604604
     },
     "MaxCategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 1.2427930071894404
     },
     "MaxCategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 0.04163676869563335
     },
     "MaxClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.9387592788971368
     },
     "MaxDecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 49.0
     },
     "MaxDecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 10.0
     },
     "MaxDecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 22.0
     },
+    "MaxFullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -53.0
+    },
     "MaxFullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": 550.0
     },
     "MaxKurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 238.18146237806315
     },
     "MaxKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "MaxMeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 110.4696486566283
     },
     "MaxMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "MaxNumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 1.7001812503765323
     },
     "MaxNumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 1.9127090565977578
     },
     "MaxNumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.10645678195030889
     },
+    "MaxOneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -5.0
+    },
     "MaxOneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": 250.0
     },
+    "MaxOneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -15.0
+    },
     "MaxOneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": 351.0
     },
     "MaxSkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 13.882652755041768
     },
     "MaxSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "MaxSqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -1.0
+    },
     "MaxSqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": 165.0
     },
     "MaxStdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 35.60424760764098
     },
     "MaxStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "MeanCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 2.1363636363636362
     },
     "MeanCardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 179.33333333333334
     },
     "MeanCategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 0.2344341403357237
     },
     "MeanCategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 0.4613654485629755
     },
     "MeanCategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 0.003545384743827898
     },
     "MeanClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.5
     },
     "MeanDecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 5.705882352941177
     },
     "MeanDecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 6.26530612244898
     },
     "MeanDecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 8.818181818181818
     },
+    "MeanFullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -53.0
+    },
     "MeanFullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": -53.3763269230769
     },
     "MeanKurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 51.413135065510026
     },
     "MeanKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "MeanMeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 46.436689696411385
     },
     "MeanMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "MeanNumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 1.240228736551128
     },
     "MeanNumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 1.4577611891821942
     },
     "MeanNumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.027870805664988743
     },
+    "MeanOneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -5.0
+    },
     "MeanOneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": -24.812192307692296
     },
+    "MeanOneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -15.0
+    },
     "MeanOneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": -15.60855769230769
     },
     "MeanSkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 3.5691918824691036
     },
     "MeanSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "MeanSqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -1.0
+    },
     "MeanSqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": -5.601249999999999
     },
     "MeanStdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 19.053877588965566
     },
     "MeanStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "MinCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 1.0
     },
     "MinCardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 70.0
     },
     "MinCategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 0.0
     },
     "MinCategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 0.2303678505246139
     },
     "MinCategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": -1.6653345369377348e-15
     },
     "MinClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.0612407211028632
     },
     "MinDecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 1.0
     },
     "MinDecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 4.0
     },
     "MinDecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 1.0
     },
+    "MinFullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -53.0
+    },
     "MinFullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": -1187.7399999999986
     },
     "MinKurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 4.073471498748891
     },
     "MinKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "MinMeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 0.9949997045790251
     },
     "MinMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "MinNumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 0.14521170237536474
     },
     "MinNumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 0.39093470087095644
     },
     "MinNumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.0008582987317293472
     },
+    "MinOneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -5.0
+    },
     "MinOneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": -568.4999999999999
     },
+    "MinOneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -15.0
+    },
     "MinOneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": -435.0
     },
     "MinSkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 1.2326742385072778
     },
     "MinSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "MinSqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -1.0
+    },
     "MinSqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": -279.0
     },
     "MinStdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 0.1954572751132885
     },
     "MinStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "MinorityClassSize": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 231
     },
     "NaiveBayesErrRate": {
-        "compute_time": 0.059335523983463645,
+        "compute_time": 0.05890540196560323,
         "value": 0.6781856595244019
     },
     "NaiveBayesKappa": {
-        "compute_time": 0.059335523983463645,
+        "compute_time": 0.05890540196560323,
         "value": 0.039699494487290043
     },
     "NumberOfCategoricalFeatures": {
-        "compute_time": 2.160598523914814e-05,
+        "compute_time": 2.093682996928692e-05,
         "value": 22
     },
     "NumberOfClasses": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 2
     },
     "NumberOfDistinctTokens": {
-        "compute_time": 0.000236984109506011,
+        "compute_time": 0.00023346696980297565,
         "value": 0
     },
     "NumberOfFeatures": {
-        "compute_time": 2.160598523914814e-05,
+        "compute_time": 2.093682996928692e-05,
         "value": 29
     },
     "NumberOfFeaturesWithMissingValues": {
-        "compute_time": 0.0077187600545585155,
+        "compute_time": 0.007131610065698624,
         "value": 8
     },
     "NumberOfInstances": {
-        "compute_time": 2.160598523914814e-05,
+        "compute_time": 2.093682996928692e-05,
         "value": 3772
     },
     "NumberOfInstancesWithMissingValues": {
-        "compute_time": 0.0077187600545585155,
+        "compute_time": 0.007131610065698624,
         "value": 3772
     },
     "NumberOfMissingValues": {
-        "compute_time": 0.0077187600545585155,
+        "compute_time": 0.007131610065698624,
         "value": 6064
     },
     "NumberOfNumericFeatures": {
-        "compute_time": 2.160598523914814e-05,
+        "compute_time": 2.093682996928692e-05,
         "value": 7
     },
     "NumberOfTokens": {
-        "compute_time": 0.000236984109506011,
+        "compute_time": 0.00023346696980297565,
         "value": 0
     },
     "NumberOfTokensContainingNumericChar": {
-        "compute_time": 0.000236984109506011,
+        "compute_time": 0.00023346696980297565,
         "value": 0
     },
     "NumericNoiseToSignalRatio": {
-        "compute_time": 0.13274331064894795,
+        "compute_time": 0.1539619469549507,
         "value": 43.499206497970064
     },
     "OneHalfPerceptronNIters": {
-        "compute_time": 0.038686589105054736,
+        "compute_time": 0.0372146510053426,
         "value": 6
     },
     "OneHalfPerceptronWeightsSum": {
-        "compute_time": 0.038698060903698206,
+        "compute_time": 0.037223159102723,
         "value": -1290.2339999999995
     },
     "OneTenthPerceptronNIters": {
-        "compute_time": 0.037826212821528316,
+        "compute_time": 0.03647300694137812,
         "value": 6
     },
     "OneTenthPerceptronWeightsSum": {
-        "compute_time": 0.03783675283193588,
+        "compute_time": 0.0364812221378088,
         "value": -811.6449999999999
     },
     "PredDet": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 8.398206098130474e+47
     },
     "PredEigen1": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 2076.940458333572
     },
     "PredEigen2": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 584.6940837111429
     },
     "PredEigen3": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 416.0684363789902
     },
     "PredPCA1": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 0.6131782342417007
     },
     "PredPCA2": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 0.17262010780474016
     },
     "PredPCA3": {
-        "compute_time": 0.08503678883425891,
+        "compute_time": 0.06268241698853672,
         "value": 0.12283650603410787
     },
     "Quartile1CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 2.0
     },
     "Quartile1CardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 107.25
     },
     "Quartile1CategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 0.07132665652246652
     },
     "Quartile1CategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 0.3014425793394888
     },
     "Quartile1CategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 0.000401382222092676
     },
     "Quartile1ClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.2806203605514316
     },
     "Quartile1DecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 1.0
     },
     "Quartile1DecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 5.0
     },
     "Quartile1DecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 3.0
     },
+    "Quartile1FullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -53.0
+    },
     "Quartile1FullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": -66.25
     },
     "Quartile1KurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 6.9324686702015095
     },
     "Quartile1KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "Quartile1MeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 2.7818163973111814
     },
     "Quartile1MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "Quartile1NumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 1.1599826109278069
     },
     "Quartile1NumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 1.3652560566996312
     },
     "Quartile1NumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.005350531172490503
     },
+    "Quartile1OneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -5.0
+    },
     "Quartile1OneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": -18.0
     },
+    "Quartile1OneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -15.0
+    },
     "Quartile1OneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": -14.25
     },
     "Quartile1SkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 1.2871359905719386
     },
     "Quartile1SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "Quartile1SqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -1.0
+    },
     "Quartile1SqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": -2.0
     },
     "Quartile1StdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 5.641815238818264
     },
     "Quartile1StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "Quartile2CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 2.0
     },
     "Quartile2CardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 191.0
     },
     "Quartile2CategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 0.17978494759170108
     },
     "Quartile2CategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 0.40854057385576326
     },
     "Quartile2CategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 0.0008944661141944213
     },
     "Quartile2ClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.5
     },
     "Quartile2DecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 2.0
     },
     "Quartile2DecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 6.0
     },
     "Quartile2DecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 6.0
     },
+    "Quartile2FullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -53.0
+    },
     "Quartile2FullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": -31.0
     },
     "Quartile2KurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 8.871303806575874
     },
     "Quartile2KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "Quartile2MeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 28.41132258295654
     },
     "Quartile2MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "Quartile2NumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 1.47782513171791
     },
     "Quartile2NumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 1.6768594976548352
     },
     "Quartile2NumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.013027973551840908
     },
+    "Quartile2OneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -5.0
+    },
     "Quartile2OneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": -3.5
     },
+    "Quartile2OneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -15.0
+    },
     "Quartile2OneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": -10.0
     },
     "Quartile2SkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 1.5381528946216996
     },
     "Quartile2SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "Quartile2SqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -1.0
+    },
     "Quartile2SqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": -1.0
     },
     "Quartile2StdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 22.30321439330161
     },
     "Quartile2StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "Quartile3CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 2.0
     },
     "Quartile3CardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 240.25
     },
     "Quartile3CategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 0.32727219276174513
     },
     "Quartile3CategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 0.5549217204785228
     },
     "Quartile3CategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 0.0021054152441979074
     },
     "Quartile3ClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.7193796394485685
     },
     "Quartile3DecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 4.0
     },
     "Quartile3DecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 7.0
     },
     "Quartile3DecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 15.0
     },
+    "Quartile3FullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": -53.0
+    },
     "Quartile3FullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": 2.25
     },
     "Quartile3KurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 33.86413491040868
     },
     "Quartile3KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "Quartile3MeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 94.17347838267801
     },
     "Quartile3MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "Quartile3NumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 1.5591768572704363
     },
     "Quartile3NumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 1.7900769788638717
     },
     "Quartile3NumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.026553810256589254
     },
+    "Quartile3OneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": -5.0
+    },
     "Quartile3OneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": 6.0
     },
+    "Quartile3OneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": -15.0
+    },
     "Quartile3OneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": -1.75
     },
     "Quartile3SkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 1.8995793407555395
     },
     "Quartile3SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "Quartile3SqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": -1.0
+    },
     "Quartile3SqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": 0.0
     },
     "Quartile3StdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 30.947640856159467
     },
     "Quartile3StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "RandomTreeDepth1ErrRate": {
-        "compute_time": 0.05467251571826637,
+        "compute_time": 0.053813572973012924,
         "value": 0.061240597751753945
     },
     "RandomTreeDepth1Kappa": {
-        "compute_time": 0.05467251571826637,
+        "compute_time": 0.053813572973012924,
         "value": 0.0
     },
     "RandomTreeDepth2ErrRate": {
-        "compute_time": 0.055194378830492496,
+        "compute_time": 0.05414533196017146,
         "value": 0.061240597751753945
     },
     "RandomTreeDepth2Kappa": {
-        "compute_time": 0.055194378830492496,
+        "compute_time": 0.05414533196017146,
         "value": 0.0
     },
     "RandomTreeDepth3ErrRate": {
-        "compute_time": 0.055694324895739555,
+        "compute_time": 0.05506708403117955,
         "value": 0.046121234356528484
     },
     "RandomTreeDepth3Kappa": {
-        "compute_time": 0.055694324895739555,
+        "compute_time": 0.05506708403117955,
         "value": 0.3551191328085659
     },
     "RatioOfCategoricalFeatures": {
-        "compute_time": 2.160598523914814e-05,
+        "compute_time": 2.093682996928692e-05,
         "value": 0.7586206896551724
     },
     "RatioOfDistinctTokens": {
-        "compute_time": 0.000236984109506011,
+        "compute_time": 0.00023346696980297565,
         "value": 0
     },
     "RatioOfFeaturesWithMissingValues": {
-        "compute_time": 0.0077187600545585155,
+        "compute_time": 0.007131610065698624,
         "value": 0.27586206896551724
     },
     "RatioOfInstancesWithMissingValues": {
-        "compute_time": 0.0077187600545585155,
+        "compute_time": 0.007131610065698624,
         "value": 1.0
     },
     "RatioOfMissingValues": {
-        "compute_time": 0.0077187600545585155,
+        "compute_time": 0.007131610065698624,
         "value": 0.05543569678575346
     },
     "RatioOfNumericFeatures": {
-        "compute_time": 2.160598523914814e-05,
+        "compute_time": 2.093682996928692e-05,
         "value": 0.2413793103448276
     },
     "RatioOfTokensContainingNumericChar": {
-        "compute_time": 0.000236984109506011,
+        "compute_time": 0.00023346696980297565,
         "value": 0
     },
     "SkewCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 3.077104198750258
     },
     "SkewCardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": -0.08243378475608776
     },
     "SkewCategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 1.8559533279845721
     },
     "SkewCategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 1.7769649555998623
     },
     "SkewCategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 3.875490250344927
     },
     "SkewClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 2.4645212079004602e-16
     },
     "SkewDecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 3.451450787668906
     },
     "SkewDecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 0.5980222656789738
     },
     "SkewDecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 0.5765667421352726
     },
+    "SkewFullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": 0.0
+    },
     "SkewFullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": -2.904979202015009
     },
     "SkewKurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 1.7025904731327763
     },
     "SkewKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "SkewMeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 0.3777827539698624
     },
     "SkewMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "SkewNumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": -1.3148700862947547
     },
     "SkewNumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": -1.268339377641566
     },
     "SkewNumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 1.5338906741146343
     },
+    "SkewOneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": 0.0
+    },
     "SkewOneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": -2.410910461022147
     },
+    "SkewOneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": 0.0
+    },
     "SkewOneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": -0.9867800143145794
     },
     "SkewSkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 1.776083146506227
     },
     "SkewSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "SkewSqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": 0.0
+    },
     "SkewSqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": -3.0316835648178238
     },
     "SkewStdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": -0.31628077149128647
     },
     "SkewStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "SqrtPerceptronNIters": {
-        "compute_time": 0.03770280280150473,
+        "compute_time": 0.03648846200667322,
         "value": 6
     },
     "SqrtPerceptronWeightsSum": {
-        "compute_time": 0.03771341987885535,
+        "compute_time": 0.03649679012596607,
         "value": -291.265
     },
     "StdevCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0035173408687114716,
+        "compute_time": 0.0033720131032168865,
         "value": 0.7101612523427369
     },
     "StdevCardinalityOfNumericFeatures": {
-        "compute_time": 0.0014439760707318783,
+        "compute_time": 0.0013578939251601696,
         "value": 88.44810154359824
     },
     "StdevCategoricalAttributeEntropy": {
-        "compute_time": 0.06723319087177515,
+        "compute_time": 0.043610990047454834,
         "value": 0.24659802585010002
     },
     "StdevCategoricalJointEntropy": {
-        "compute_time": 0.06400116207078099,
+        "compute_time": 0.06501227105036378,
         "value": 0.23956528678973543
     },
     "StdevCategoricalMutualInformation": {
-        "compute_time": 0.06907475017942488,
+        "compute_time": 0.0693531020078808,
         "value": 0.00886031490652107
     },
     "StdevClassProbability": {
-        "compute_time": 0.001252528978511691,
+        "compute_time": 0.0011928300373256207,
         "value": 0.6204993228333702
     },
     "StdevDecisionTreeAttribute": {
-        "compute_time": 0.03904539393261075,
+        "compute_time": 0.03865064703859389,
         "value": 11.444238211226388
     },
     "StdevDecisionTreeBranchLength": {
-        "compute_time": 0.039101457921788096,
+        "compute_time": 0.03870894014835358,
         "value": 1.551551779725726
     },
     "StdevDecisionTreeLevelSize": {
-        "compute_time": 0.03914717095904052,
+        "compute_time": 0.03875288018025458,
         "value": 7.386720271110607
     },
+    "StdevFullPerceptronBias": {
+        "compute_time": 0.038931607035920024,
+        "value": 0.0
+    },
     "StdevFullPerceptronWeights": {
-        "compute_time": 0.03977922978810966,
+        "compute_time": 0.03898488008417189,
         "value": 208.9336462921427
     },
     "StdevKurtosisOfNumericFeatures": {
-        "compute_time": 0.001857818104326725,
+        "compute_time": 0.0020050201565027237,
         "value": 92.56654555918352
     },
     "StdevKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 4.772399552166462e-05,
+        "compute_time": 4.654889926314354e-05,
         "value": NaN
     },
     "StdevMeansOfNumericFeatures": {
-        "compute_time": 0.0017811150755733252,
+        "compute_time": 0.0017744090873748064,
         "value": 52.35637003353562
     },
     "StdevMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 4.9187103286385536e-05,
+        "compute_time": 4.794984124600887e-05,
         "value": NaN
     },
     "StdevNumericAttributeEntropy": {
-        "compute_time": 0.020017019007354975,
+        "compute_time": 0.040799334179610014,
         "value": 0.5768649195847191
     },
     "StdevNumericJointEntropy": {
-        "compute_time": 0.02730743191204965,
+        "compute_time": 0.027461488731205463,
         "value": 0.56604507540674
     },
     "StdevNumericMutualInformation": {
-        "compute_time": 0.11272568674758077,
+        "compute_time": 0.11316189379431307,
         "value": 0.039885364866017826
     },
+    "StdevOneHalfPerceptronBias": {
+        "compute_time": 0.03771837311796844,
+        "value": 0.0
+    },
     "StdevOneHalfPerceptronWeights": {
-        "compute_time": 0.039217038080096245,
+        "compute_time": 0.03774726600386202,
         "value": 125.24182377806707
     },
+    "StdevOneTenthPerceptronBias": {
+        "compute_time": 0.03698103199712932,
+        "value": 0.0
+    },
     "StdevOneTenthPerceptronWeights": {
-        "compute_time": 0.038355675991624594,
+        "compute_time": 0.037004386307671666,
         "value": 84.65172899532865
     },
     "StdevSkewnessOfNumericFeatures": {
-        "compute_time": 0.0018326959107071161,
+        "compute_time": 0.0018677711486816406,
         "value": 5.060654984907634
     },
     "StdevSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 4.773004911839962e-05,
+        "compute_time": 4.652794450521469e-05,
         "value": NaN
     },
+    "StdevSqrtPerceptronBias": {
+        "compute_time": 0.036990405060350895,
+        "value": 0.0
+    },
     "StdevSqrtPerceptronWeights": {
-        "compute_time": 0.038225420052185655,
+        "compute_time": 0.037011667154729366,
         "value": 46.94289723544812
     },
     "StdevStdDevOfNumericFeatures": {
-        "compute_time": 0.001887504942715168,
+        "compute_time": 0.0019193461630493402,
         "value": 15.425433204049687
     },
     "StdevStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 4.812306724488735e-05,
+        "compute_time": 4.677777178585529e-05,
         "value": NaN
     },
     "kNN1NErrRate": {
-        "compute_time": 0.30677097267471254,
+        "compute_time": 0.3031897589098662,
         "value": 0.09093279580094993
     },
     "kNN1NKappa": {
-        "compute_time": 0.30677097267471254,
+        "compute_time": 0.3031897589098662,
         "value": 0.16702041294319114
     }
 }

--- a/tests/data/dataset_metafeatures/small_test_dataset_mf.json
+++ b/tests/data/dataset_metafeatures/small_test_dataset_mf.json
@@ -1,1102 +1,1246 @@
 {
     "CategoricalNoiseToSignalRatio": {
-        "compute_time": 0.004891266580671072,
+        "compute_time": 0.006257861154153943,
         "value": 1.0834895643494507
     },
     "ClassEntropy": {
-        "compute_time": 0.0003845838364213705,
+        "compute_time": 0.0006449930369853973,
         "value": 1.3321790402101223
     },
     "DecisionStumpErrRate": {
-        "compute_time": 0.006311351666226983,
+        "compute_time": 0.009164798306301236,
         "value": 0.7
     },
     "DecisionStumpKappa": {
-        "compute_time": 0.006311351666226983,
+        "compute_time": 0.009164798306301236,
         "value": 0.05882352941176472
     },
     "DecisionTreeHeight": {
-        "compute_time": 0.003527351887896657,
+        "compute_time": 0.006444388534873724,
         "value": 4
     },
     "DecisionTreeLeafCount": {
-        "compute_time": 0.003527351887896657,
+        "compute_time": 0.006444388534873724,
         "value": 5
     },
     "DecisionTreeNodeCount": {
-        "compute_time": 0.003527351887896657,
+        "compute_time": 0.006444388534873724,
         "value": 9
     },
     "DecisionTreeWidth": {
-        "compute_time": 0.0035418407060205936,
+        "compute_time": 0.006458525313064456,
         "value": 4
     },
     "Dimensionality": {
-        "compute_time": 4.010205157101154e-05,
+        "compute_time": 0.0002616711426526308,
         "value": 0.5
     },
     "EquivalentNumberOfCategoricalFeatures": {
-        "compute_time": 0.0038643034640699625,
+        "compute_time": 0.004695221781730652,
         "value": 2.661227372130404
     },
     "EquivalentNumberOfNumericFeatures": {
-        "compute_time": 0.007282402366399765,
+        "compute_time": 0.008382619824260473,
         "value": 3.521069926069284
     },
     "FullPerceptronNIters": {
-        "compute_time": 0.009216182632371783,
+        "compute_time": 0.016041310504078865,
         "value": 7
     },
     "FullPerceptronWeightsSum": {
-        "compute_time": 0.00922303250990808,
+        "compute_time": 0.016048306599259377,
         "value": -13.024999999999999
     },
     "KurtosisCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": -2.0
     },
     "KurtosisCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": -2.0
     },
     "KurtosisCategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": -2.0
     },
     "KurtosisCategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": -2.0000000000000004
     },
     "KurtosisCategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": -2.0
     },
     "KurtosisClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": -0.6666666666666661
     },
     "KurtosisDecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": -0.8512709572742021
     },
     "KurtosisDecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 0.24999999999999867
     },
     "KurtosisDecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
+        "value": -0.9030470914127422
+    },
+    "KurtosisFullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
         "value": -0.9030470914127422
     },
     "KurtosisFullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": -0.26035017128611226
     },
     "KurtosisKurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -2.0
     },
     "KurtosisKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "KurtosisMeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": -2.0
     },
     "KurtosisMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "KurtosisNumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": -2.0
     },
     "KurtosisNumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": -2.0
     },
     "KurtosisNumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": -2.0
     },
+    "KurtosisOneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": -0.6666666666666665
+    },
     "KurtosisOneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": 0.061710435495173854
     },
+    "KurtosisOneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": -1.0
+    },
     "KurtosisOneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": 0.6203674707874316
     },
     "KurtosisSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": -1.9999999999999998
     },
     "KurtosisSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "KurtosisSqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -0.6666666666666665
+    },
     "KurtosisSqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": 1.4810950726966965
     },
     "KurtosisStdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": -1.9999999999999998
     },
     "KurtosisStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "LinearDiscriminantAnalysisErrRate": {
-        "compute_time": 0.006871173856779933,
+        "compute_time": 0.009682535426691175,
         "value": 0.7
     },
     "LinearDiscriminantAnalysisKappa": {
-        "compute_time": 0.006871173856779933,
+        "compute_time": 0.009682535426691175,
         "value": 0.042397660818713545
     },
     "MajorityClassSize": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 4
     },
     "MaxCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 6.0
     },
     "MaxCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 9.0
     },
     "MaxCategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 1.4750763110546947
     },
     "MaxCategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 1.945910149055313
     },
     "MaxCategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.8062004214655205
     },
     "MaxClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.4
     },
     "MaxDecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 5.0
     },
     "MaxDecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 3.0
     },
     "MaxDecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 4.0
     },
+    "MaxFullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": 1.0
+    },
     "MaxFullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": 4.0
     },
     "MaxKurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -0.833323850726984
     },
     "MaxKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "MaxMeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.5714285714285714
     },
     "MaxMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "MaxNumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.6931471805599453
     },
     "MaxNumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 1.5498260458782016
     },
     "MaxNumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.4101163182884089
     },
+    "MaxOneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": 1.0
+    },
     "MaxOneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": 3.0
     },
+    "MaxOneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": -1.0
+    },
     "MaxOneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": 2.0
     },
     "MaxSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.5062323443248941
     },
     "MaxSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "MaxSqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -1.0
+    },
     "MaxSqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": 1.0
     },
     "MaxStdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 2.3704530408864084
     },
     "MaxStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "MeanCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 4.0
     },
     "MeanCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 7.5
     },
     "MeanCategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 1.0429703065547942
     },
     "MeanCategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 1.846988748800701
     },
     "MeanCategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.5005882075922236
     },
     "MeanClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.25
     },
     "MeanDecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 2.25
     },
     "MeanDecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 2.6
     },
     "MeanDecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 2.25
     },
+    "MeanFullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": -1.5
+    },
     "MeanFullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": -0.3618055555555555
     },
     "MeanKurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -1.3493249532290488
     },
     "MeanKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "MeanMeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.5505892857142857
     },
     "MeanMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "MeanNumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.6880276426302085
     },
     "MeanNumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 1.468060203499046
     },
     "MeanNumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.3783449542841908
     },
+    "MeanOneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": -1.25
+    },
     "MeanOneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": -0.2720833333333333
     },
+    "MeanOneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": -2.0
+    },
     "MeanOneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": -0.5516666666666666
     },
     "MeanSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.42456949227053975
     },
     "MeanSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "MeanSqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -1.25
+    },
     "MeanSqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": -0.5483611111111111
     },
     "MeanStdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 1.306626611641099
     },
     "MeanStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "MinCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 2.0
     },
     "MinCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 6.0
     },
     "MinCategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 0.6108643020548935
     },
     "MinCategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 1.7480673485460894
     },
     "MinCategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.1949759937189266
     },
     "MinClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.2
     },
     "MinDecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 1.0
     },
     "MinDecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 1.0
     },
     "MinDecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 1.0
     },
+    "MinFullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": -5.0
+    },
     "MinFullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": -3.0
     },
     "MinKurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -1.8653260557311135
     },
     "MinKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "MinMeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.5297499999999999
     },
     "MinMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "MinNumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.6829081047004717
     },
     "MinNumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 1.3862943611198906
     },
     "MinNumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.3465735902799727
     },
+    "MinOneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": -2.0
+    },
     "MinOneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
+        "value": -3.0
+    },
+    "MinOneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
         "value": -3.0
     },
     "MinOneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": -4.0
     },
     "MinSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.3429066402161854
     },
     "MinSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "MinSqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -2.0
+    },
     "MinSqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": -4.159
     },
     "MinStdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 0.24280018239578932
     },
     "MinStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "MinorityClassSize": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 2
     },
     "NaiveBayesErrRate": {
-        "compute_time": 0.007427818840369582,
+        "compute_time": 0.010259006405249238,
         "value": 0.7
     },
     "NaiveBayesKappa": {
-        "compute_time": 0.007427818840369582,
+        "compute_time": 0.010259006405249238,
         "value": -0.05555555555555547
     },
     "NumberOfCategoricalFeatures": {
-        "compute_time": 1.9602011889219284e-05,
+        "compute_time": 0.0001287730410695076,
         "value": 2
     },
     "NumberOfClasses": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 4
     },
     "NumberOfDistinctTokens": {
-        "compute_time": 4.924694076180458e-05,
+        "compute_time": 5.69287221878767e-05,
         "value": 0
     },
     "NumberOfFeatures": {
-        "compute_time": 1.9602011889219284e-05,
+        "compute_time": 0.0001287730410695076,
         "value": 5
     },
     "NumberOfFeaturesWithMissingValues": {
-        "compute_time": 0.001288380939513445,
+        "compute_time": 0.006173023954033852,
         "value": 4
     },
     "NumberOfInstances": {
-        "compute_time": 1.9602011889219284e-05,
+        "compute_time": 0.0001287730410695076,
         "value": 10
     },
     "NumberOfInstancesWithMissingValues": {
-        "compute_time": 0.001288380939513445,
+        "compute_time": 0.006173023954033852,
         "value": 10
     },
     "NumberOfMissingValues": {
-        "compute_time": 0.001288380939513445,
+        "compute_time": 0.006173023954033852,
         "value": 18
     },
     "NumberOfNumericFeatures": {
-        "compute_time": 1.9602011889219284e-05,
+        "compute_time": 0.0001287730410695076,
         "value": 3
     },
     "NumberOfTokens": {
-        "compute_time": 4.924694076180458e-05,
+        "compute_time": 5.69287221878767e-05,
         "value": 0
     },
     "NumberOfTokensContainingNumericChar": {
-        "compute_time": 4.924694076180458e-05,
+        "compute_time": 5.69287221878767e-05,
         "value": 0
     },
     "NumericNoiseToSignalRatio": {
-        "compute_time": 0.011570326518267393,
+        "compute_time": 0.015065940795466304,
         "value": 0.8185194089132799
     },
     "OneHalfPerceptronNIters": {
-        "compute_time": 0.009213292738422751,
+        "compute_time": 0.015977420611307025,
         "value": 7
     },
     "OneHalfPerceptronWeightsSum": {
-        "compute_time": 0.009220540756359696,
+        "compute_time": 0.015984741505235434,
         "value": -9.794999999999998
     },
     "OneTenthPerceptronNIters": {
-        "compute_time": 0.009071480948477983,
+        "compute_time": 0.015757451532408595,
         "value": 6
     },
     "OneTenthPerceptronWeightsSum": {
-        "compute_time": 0.009078587871044874,
+        "compute_time": 0.01576475682668388,
         "value": -19.86
     },
     "PredDet": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 1.0271201550018805e-08
     },
     "PredEigen1": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 6.114621511001614
     },
     "PredEigen2": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 0.39471862161052784
     },
     "PredEigen3": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 0.2437796639097066
     },
     "PredPCA1": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 0.8662514396391524
     },
     "PredPCA2": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 0.05591933590775793
     },
     "PredPCA3": {
-        "compute_time": 0.003375102998688817,
+        "compute_time": 0.0065355615224689245,
         "value": 0.03453598631355685
     },
     "Quartile1CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 3.0
     },
     "Quartile1CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 6.75
     },
     "Quartile1CategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 0.8269173043048439
     },
     "Quartile1CategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 1.7975280486733953
     },
     "Quartile1CategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.3477821006555751
     },
     "Quartile1ClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.2
     },
     "Quartile1DecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 1.0
     },
     "Quartile1DecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 3.0
     },
     "Quartile1DecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 1.75
     },
+    "Quartile1FullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": -2.0
+    },
     "Quartile1FullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": -2.0
     },
     "Quartile1KurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -1.6073255044800812
     },
     "Quartile1KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "Quartile1MeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.5401696428571428
     },
     "Quartile1MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "Quartile1NumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.6854678736653401
     },
     "Quartile1NumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 1.4271772823094682
     },
     "Quartile1NumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.36245927228208175
     },
+    "Quartile1OneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": -2.0
+    },
     "Quartile1OneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": -1.0
     },
+    "Quartile1OneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": -2.25
+    },
     "Quartile1OneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": -1.0
     },
     "Quartile1SkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.3837380662433626
     },
     "Quartile1SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "Quartile1SqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -1.25
+    },
     "Quartile1SqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": -1.0
     },
     "Quartile1StdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 0.7747133970184441
     },
     "Quartile1StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "Quartile2CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 4.0
     },
     "Quartile2CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 7.5
     },
     "Quartile2CategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 1.0429703065547942
     },
     "Quartile2CategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 1.846988748800701
     },
     "Quartile2CategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.5005882075922236
     },
     "Quartile2ClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.2
     },
     "Quartile2DecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 1.5
     },
     "Quartile2DecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 3.0
     },
     "Quartile2DecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 2.0
     },
+    "Quartile2FullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": -1.0
+    },
     "Quartile2FullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": 0.0
     },
     "Quartile2KurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -1.3493249532290488
     },
     "Quartile2KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "Quartile2MeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.5505892857142857
     },
     "Quartile2MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "Quartile2NumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.6880276426302085
     },
     "Quartile2NumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 1.468060203499046
     },
     "Quartile2NumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.3783449542841908
     },
+    "Quartile2OneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": -2.0
+    },
     "Quartile2OneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": 0.0
     },
+    "Quartile2OneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": -2.0
+    },
     "Quartile2OneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": 0.0
     },
     "Quartile2SkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.42456949227053975
     },
     "Quartile2SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "Quartile2SqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -1.0
+    },
     "Quartile2SqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": -0.2899999999999999
     },
     "Quartile2StdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 1.306626611641099
     },
     "Quartile2StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "Quartile3CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 5.0
     },
     "Quartile3CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 8.25
     },
     "Quartile3CategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 1.2590233088047444
     },
     "Quartile3CategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 1.896449448928007
     },
     "Quartile3CategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.653394314528872
     },
     "Quartile3ClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.25
     },
     "Quartile3DecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 2.75
     },
     "Quartile3DecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 3.0
     },
     "Quartile3DecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 2.5
     },
+    "Quartile3FullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": -0.5
+    },
     "Quartile3FullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": 0.04374999999999998
     },
     "Quartile3KurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": -1.0913244019780164
     },
     "Quartile3KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "Quartile3MeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.5610089285714286
     },
     "Quartile3MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "Quartile3NumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.6905874115950769
     },
     "Quartile3NumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 1.5089431246886238
     },
     "Quartile3NumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.39423063628629984
     },
+    "Quartile3OneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": -1.25
+    },
     "Quartile3OneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": 0.20325
     },
+    "Quartile3OneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": -1.75
+    },
     "Quartile3OneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": 0.0
     },
     "Quartile3SkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.46540091829771685
     },
     "Quartile3SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "Quartile3SqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -1.0
+    },
     "Quartile3SqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": 0.0
     },
     "Quartile3StdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 1.8385398262637536
     },
     "Quartile3StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "RandomTreeDepth1ErrRate": {
-        "compute_time": 0.006247562821954489,
+        "compute_time": 0.009212250355631113,
         "value": 0.8
     },
     "RandomTreeDepth1Kappa": {
-        "compute_time": 0.006247562821954489,
+        "compute_time": 0.009212250355631113,
         "value": -0.1356209150326797
     },
     "RandomTreeDepth2ErrRate": {
-        "compute_time": 0.006273259874433279,
+        "compute_time": 0.009589832508936524,
         "value": 0.8
     },
     "RandomTreeDepth2Kappa": {
-        "compute_time": 0.006273259874433279,
+        "compute_time": 0.009589832508936524,
         "value": -0.08187134502923976
     },
     "RandomTreeDepth3ErrRate": {
-        "compute_time": 0.006270488956943154,
+        "compute_time": 0.0091382903046906,
         "value": 0.8
     },
     "RandomTreeDepth3Kappa": {
-        "compute_time": 0.006270488956943154,
+        "compute_time": 0.0091382903046906,
         "value": -0.02631578947368418
     },
     "RatioOfCategoricalFeatures": {
-        "compute_time": 1.9602011889219284e-05,
+        "compute_time": 0.0001287730410695076,
         "value": 0.4
     },
     "RatioOfDistinctTokens": {
-        "compute_time": 4.924694076180458e-05,
+        "compute_time": 5.69287221878767e-05,
         "value": 0
     },
     "RatioOfFeaturesWithMissingValues": {
-        "compute_time": 0.001288380939513445,
+        "compute_time": 0.006173023954033852,
         "value": 0.8
     },
     "RatioOfInstancesWithMissingValues": {
-        "compute_time": 0.001288380939513445,
+        "compute_time": 0.006173023954033852,
         "value": 1.0
     },
     "RatioOfMissingValues": {
-        "compute_time": 0.001288380939513445,
+        "compute_time": 0.006173023954033852,
         "value": 0.36
     },
     "RatioOfNumericFeatures": {
-        "compute_time": 1.9602011889219284e-05,
+        "compute_time": 0.0001287730410695076,
         "value": 0.6
     },
     "RatioOfTokensContainingNumericChar": {
-        "compute_time": 4.924694076180458e-05,
+        "compute_time": 5.69287221878767e-05,
         "value": 0
     },
     "SkewCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 0.0
     },
     "SkewCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 0.0
     },
     "SkewCategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": -4.3002068602548916e-16
     },
     "SkewCategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 3.360166224435086e-15
     },
     "SkewCategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.0
     },
     "SkewClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 1.154700538379252
     },
     "SkewDecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 0.9575491625535641
     },
     "SkewDecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": -1.4999999999999996
     },
     "SkewDecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 0.6520236646847545
     },
+    "SkewFullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": -0.6520236646847545
+    },
     "SkewFullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": 0.40452762963600386
     },
     "SkewKurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": 0.0
     },
     "SkewKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "SkewMeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.0
     },
     "SkewMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "SkewNumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": -3.2549324088873523e-14
     },
     "SkewNumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 4.065822249747896e-15
     },
     "SkewNumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.0
     },
+    "SkewOneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": 1.1547005383792515
+    },
     "SkewOneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": 0.16988852993565123
     },
+    "SkewOneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": 0.0
+    },
     "SkewOneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": -0.543491413263422
     },
     "SkewSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": -9.954206526050281e-16
     },
     "SkewSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "SkewSqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": -1.1547005383792515
+    },
     "SkewSqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": -1.0338183648458683
     },
     "SkewStdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": -2.7664266387282363e-16
     },
     "SkewStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "SqrtPerceptronNIters": {
-        "compute_time": 0.009232969023287296,
+        "compute_time": 0.015973137691617012,
         "value": 7
     },
     "SqrtPerceptronWeightsSum": {
-        "compute_time": 0.009240191895514727,
+        "compute_time": 0.01598068862222135,
         "value": -19.741
     },
     "StdevCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0005935528315603733,
+        "compute_time": 0.0022671909537166357,
         "value": 2.8284271247461903
     },
     "StdevCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005602550227195024,
+        "compute_time": 0.0017578268889337778,
         "value": 2.1213203435596424
     },
     "StdevCategoricalAttributeEntropy": {
-        "compute_time": 0.001412208890542388,
+        "compute_time": 0.002208233578130603,
         "value": 0.6110901719466091
     },
     "StdevCategoricalJointEntropy": {
-        "compute_time": 0.0033199565950781107,
+        "compute_time": 0.0041864297818392515,
         "value": 0.1398959858490094
     },
     "StdevCategoricalMutualInformation": {
-        "compute_time": 0.0034781997092068195,
+        "compute_time": 0.0040486936923116446,
         "value": 0.4322009376864835
     },
     "StdevClassProbability": {
-        "compute_time": 0.0008661109022796154,
+        "compute_time": 0.00475167203694582,
         "value": 0.1
     },
     "StdevDecisionTreeAttribute": {
-        "compute_time": 0.0039195348508656025,
+        "compute_time": 0.00683898339048028,
         "value": 1.8929694486000912
     },
     "StdevDecisionTreeBranchLength": {
-        "compute_time": 0.003919197712093592,
+        "compute_time": 0.006850322475656867,
         "value": 0.8944271909999161
     },
     "StdevDecisionTreeLevelSize": {
-        "compute_time": 0.003951160935685039,
+        "compute_time": 0.007032109424471855,
         "value": 1.2583057392117916
     },
+    "StdevFullPerceptronBias": {
+        "compute_time": 0.016396304592490196,
+        "value": 2.516611478423583
+    },
     "StdevFullPerceptronWeights": {
-        "compute_time": 0.009596982505172491,
+        "compute_time": 0.016428433591499925,
         "value": 1.679197509346898
     },
     "StdevKurtosisOfNumericFeatures": {
-        "compute_time": 0.000855493824928999,
+        "compute_time": 0.002101596910506487,
         "value": 0.7297357573578896
     },
     "StdevKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.2351974621415138e-05,
+        "compute_time": 2.628588117659092e-05,
         "value": NaN
     },
     "StdevMeansOfNumericFeatures": {
-        "compute_time": 0.0007897447794675827,
+        "compute_time": 0.0030385558493435383,
         "value": 0.029471200487310768
     },
     "StdevMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.299295738339424e-05,
+        "compute_time": 2.6629772037267685e-05,
         "value": NaN
     },
     "StdevNumericAttributeEntropy": {
-        "compute_time": 0.004672640934586525,
+        "compute_time": 0.007328480947762728,
         "value": 0.007240119973317253
     },
     "StdevNumericJointEntropy": {
-        "compute_time": 0.006831580772995949,
+        "compute_time": 0.0076274387538433075,
         "value": 0.1156343632314625
     },
     "StdevNumericMutualInformation": {
-        "compute_time": 0.006897095590829849,
+        "compute_time": 0.007736874744296074,
         "value": 0.04493149386985759
     },
+    "StdevOneHalfPerceptronBias": {
+        "compute_time": 0.016326570650562644,
+        "value": 1.5
+    },
     "StdevOneHalfPerceptronWeights": {
-        "compute_time": 0.009594653733074665,
+        "compute_time": 0.016333519713953137,
         "value": 1.2923109615833843
     },
+    "StdevOneTenthPerceptronBias": {
+        "compute_time": 0.01610813965089619,
+        "value": 0.816496580927726
+    },
     "StdevOneTenthPerceptronWeights": {
-        "compute_time": 0.009422431932762265,
+        "compute_time": 0.01612143567763269,
         "value": 1.2790677408621818
     },
     "StdevSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008015669882297516,
+        "compute_time": 0.00207911292091012,
         "value": 0.11548871291733546
     },
     "StdevSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.235989086329937e-05,
+        "compute_time": 2.5967834517359734e-05,
         "value": NaN
     },
+    "StdevSqrtPerceptronBias": {
+        "compute_time": 0.016322739655151963,
+        "value": 0.5
+    },
     "StdevSqrtPerceptronWeights": {
-        "compute_time": 0.009582721861079335,
+        "compute_time": 0.016332585597410798,
         "value": 1.1668376102655238
     },
     "StdevStdDevOfNumericFeatures": {
-        "compute_time": 0.0008303120266646147,
+        "compute_time": 0.002423203084617853,
         "value": 1.5044777642496585
     },
     "StdevStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.260785549879074e-05,
+        "compute_time": 2.6084715500473976e-05,
         "value": NaN
     },
     "kNN1NErrRate": {
-        "compute_time": 0.008464587619528174,
+        "compute_time": 0.011327998479828238,
         "value": 0.8
     },
     "kNN1NKappa": {
-        "compute_time": 0.008464587619528174,
+        "compute_time": 0.011327998479828238,
         "value": -0.02631578947368407
     }
 }

--- a/tests/data/dataset_metafeatures/small_test_dataset_mf.json
+++ b/tests/data/dataset_metafeatures/small_test_dataset_mf.json
@@ -1,926 +1,1102 @@
 {
     "CategoricalNoiseToSignalRatio": {
-        "compute_time": 0.005346329984604381,
+        "compute_time": 0.004891266580671072,
         "value": 1.0834895643494507
     },
     "ClassEntropy": {
-        "compute_time": 0.000441155003500171,
+        "compute_time": 0.0003845838364213705,
         "value": 1.3321790402101223
     },
     "DecisionStumpErrRate": {
-        "compute_time": 0.006736217983416282,
+        "compute_time": 0.006311351666226983,
         "value": 0.7
     },
     "DecisionStumpKappa": {
-        "compute_time": 0.006736217983416282,
+        "compute_time": 0.006311351666226983,
         "value": 0.05882352941176472
     },
     "DecisionTreeHeight": {
-        "compute_time": 0.0038008579722372815,
+        "compute_time": 0.003527351887896657,
         "value": 4
     },
     "DecisionTreeLeafCount": {
-        "compute_time": 0.0038008579722372815,
+        "compute_time": 0.003527351887896657,
         "value": 5
     },
     "DecisionTreeNodeCount": {
-        "compute_time": 0.0038008579722372815,
+        "compute_time": 0.003527351887896657,
         "value": 9
     },
     "DecisionTreeWidth": {
-        "compute_time": 0.0038148829771671444,
+        "compute_time": 0.0035418407060205936,
         "value": 4
     },
     "Dimensionality": {
-        "compute_time": 5.145699833519757e-05,
+        "compute_time": 4.010205157101154e-05,
         "value": 0.5
     },
     "EquivalentNumberOfCategoricalFeatures": {
-        "compute_time": 0.00424534898775164,
+        "compute_time": 0.0038643034640699625,
         "value": 2.661227372130404
     },
     "EquivalentNumberOfNumericFeatures": {
-        "compute_time": 0.008189906991901807,
+        "compute_time": 0.007282402366399765,
         "value": 3.521069926069284
     },
+    "FullPerceptronNIters": {
+        "compute_time": 0.009216182632371783,
+        "value": 7
+    },
+    "FullPerceptronWeightsSum": {
+        "compute_time": 0.00922303250990808,
+        "value": -13.024999999999999
+    },
     "KurtosisCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": -2.0
     },
     "KurtosisCardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": -2.0
     },
     "KurtosisCategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": -2.0
     },
     "KurtosisCategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": -2.0000000000000004
     },
     "KurtosisCategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": -2.0
     },
     "KurtosisClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": -0.6666666666666661
     },
     "KurtosisDecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": -0.8512709572742021
     },
     "KurtosisDecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 0.24999999999999867
     },
     "KurtosisDecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": -0.9030470914127422
     },
+    "KurtosisFullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": -0.26035017128611226
+    },
     "KurtosisKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -2.0
     },
     "KurtosisKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "KurtosisMeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": -2.0
     },
     "KurtosisMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "KurtosisNumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": -2.0
     },
     "KurtosisNumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": -2.0
     },
     "KurtosisNumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": -2.0
     },
+    "KurtosisOneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": 0.061710435495173854
+    },
+    "KurtosisOneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": 0.6203674707874316
+    },
     "KurtosisSkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": -1.9999999999999998
     },
     "KurtosisSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "KurtosisSqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": 1.4810950726966965
+    },
     "KurtosisStdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": -1.9999999999999998
     },
     "KurtosisStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "LinearDiscriminantAnalysisErrRate": {
-        "compute_time": 0.007150971970986575,
+        "compute_time": 0.006871173856779933,
         "value": 0.7
     },
     "LinearDiscriminantAnalysisKappa": {
-        "compute_time": 0.007150971970986575,
+        "compute_time": 0.006871173856779933,
         "value": 0.042397660818713545
     },
     "MajorityClassSize": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 4
     },
     "MaxCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 6.0
     },
     "MaxCardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 9.0
     },
     "MaxCategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 1.4750763110546947
     },
     "MaxCategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 1.945910149055313
     },
     "MaxCategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.8062004214655205
     },
     "MaxClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.4
     },
     "MaxDecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 5.0
     },
     "MaxDecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 3.0
     },
     "MaxDecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
+        "value": 4.0
+    },
+    "MaxFullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
         "value": 4.0
     },
     "MaxKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -0.833323850726984
     },
     "MaxKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "MaxMeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.5714285714285714
     },
     "MaxMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "MaxNumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.6931471805599453
     },
     "MaxNumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 1.5498260458782016
     },
     "MaxNumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.4101163182884089
     },
+    "MaxOneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": 3.0
+    },
+    "MaxOneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": 2.0
+    },
     "MaxSkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.5062323443248941
     },
     "MaxSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "MaxSqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": 1.0
+    },
     "MaxStdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 2.3704530408864084
     },
     "MaxStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "MeanCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 4.0
     },
     "MeanCardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 7.5
     },
     "MeanCategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 1.0429703065547942
     },
     "MeanCategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 1.846988748800701
     },
     "MeanCategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.5005882075922236
     },
     "MeanClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.25
     },
     "MeanDecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 2.25
     },
     "MeanDecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 2.6
     },
     "MeanDecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 2.25
     },
+    "MeanFullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": -0.3618055555555555
+    },
     "MeanKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -1.3493249532290488
     },
     "MeanKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "MeanMeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.5505892857142857
     },
     "MeanMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "MeanNumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.6880276426302085
     },
     "MeanNumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 1.468060203499046
     },
     "MeanNumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.3783449542841908
     },
+    "MeanOneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": -0.2720833333333333
+    },
+    "MeanOneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": -0.5516666666666666
+    },
     "MeanSkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.42456949227053975
     },
     "MeanSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "MeanSqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": -0.5483611111111111
+    },
     "MeanStdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 1.306626611641099
     },
     "MeanStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "MinCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 2.0
     },
     "MinCardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 6.0
     },
     "MinCategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 0.6108643020548935
     },
     "MinCategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 1.7480673485460894
     },
     "MinCategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.1949759937189266
     },
     "MinClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.2
     },
     "MinDecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 1.0
     },
     "MinDecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 1.0
     },
     "MinDecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 1.0
     },
+    "MinFullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": -3.0
+    },
     "MinKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -1.8653260557311135
     },
     "MinKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "MinMeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.5297499999999999
     },
     "MinMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "MinNumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.6829081047004717
     },
     "MinNumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 1.3862943611198906
     },
     "MinNumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.3465735902799727
     },
+    "MinOneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": -3.0
+    },
+    "MinOneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": -4.0
+    },
     "MinSkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.3429066402161854
     },
     "MinSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "MinSqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": -4.159
+    },
     "MinStdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 0.24280018239578932
     },
     "MinStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "MinorityClassSize": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 2
     },
     "NaiveBayesErrRate": {
-        "compute_time": 0.00838631197984796,
+        "compute_time": 0.007427818840369582,
         "value": 0.7
     },
     "NaiveBayesKappa": {
-        "compute_time": 0.00838631197984796,
+        "compute_time": 0.007427818840369582,
         "value": -0.05555555555555547
     },
     "NumberOfCategoricalFeatures": {
-        "compute_time": 2.5093002477660775e-05,
+        "compute_time": 1.9602011889219284e-05,
         "value": 2
     },
     "NumberOfClasses": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 4
     },
     "NumberOfDistinctTokens": {
-        "compute_time": 5.389300349634141e-05,
+        "compute_time": 4.924694076180458e-05,
         "value": 0
     },
     "NumberOfFeatures": {
-        "compute_time": 2.5093002477660775e-05,
+        "compute_time": 1.9602011889219284e-05,
         "value": 5
     },
     "NumberOfFeaturesWithMissingValues": {
-        "compute_time": 0.0015022940060589463,
+        "compute_time": 0.001288380939513445,
         "value": 4
     },
     "NumberOfInstances": {
-        "compute_time": 2.5093002477660775e-05,
+        "compute_time": 1.9602011889219284e-05,
         "value": 10
     },
     "NumberOfInstancesWithMissingValues": {
-        "compute_time": 0.0015022940060589463,
+        "compute_time": 0.001288380939513445,
         "value": 10
     },
     "NumberOfMissingValues": {
-        "compute_time": 0.0015022940060589463,
+        "compute_time": 0.001288380939513445,
         "value": 18
     },
     "NumberOfNumericFeatures": {
-        "compute_time": 2.5093002477660775e-05,
+        "compute_time": 1.9602011889219284e-05,
         "value": 3
     },
     "NumberOfTokens": {
-        "compute_time": 5.389300349634141e-05,
+        "compute_time": 4.924694076180458e-05,
         "value": 0
     },
     "NumberOfTokensContainingNumericChar": {
-        "compute_time": 5.389300349634141e-05,
+        "compute_time": 4.924694076180458e-05,
         "value": 0
     },
     "NumericNoiseToSignalRatio": {
-        "compute_time": 0.013097035975079052,
+        "compute_time": 0.011570326518267393,
         "value": 0.8185194089132799
     },
+    "OneHalfPerceptronNIters": {
+        "compute_time": 0.009213292738422751,
+        "value": 7
+    },
+    "OneHalfPerceptronWeightsSum": {
+        "compute_time": 0.009220540756359696,
+        "value": -9.794999999999998
+    },
+    "OneTenthPerceptronNIters": {
+        "compute_time": 0.009071480948477983,
+        "value": 6
+    },
+    "OneTenthPerceptronWeightsSum": {
+        "compute_time": 0.009078587871044874,
+        "value": -19.86
+    },
     "PredDet": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 1.0271201550018805e-08
     },
     "PredEigen1": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 6.114621511001614
     },
     "PredEigen2": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 0.39471862161052784
     },
     "PredEigen3": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 0.2437796639097066
     },
     "PredPCA1": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 0.8662514396391524
     },
     "PredPCA2": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 0.05591933590775793
     },
     "PredPCA3": {
-        "compute_time": 0.0036651159753091633,
+        "compute_time": 0.003375102998688817,
         "value": 0.03453598631355685
     },
     "Quartile1CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 3.0
     },
     "Quartile1CardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 6.75
     },
     "Quartile1CategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 0.8269173043048439
     },
     "Quartile1CategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 1.7975280486733953
     },
     "Quartile1CategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.3477821006555751
     },
     "Quartile1ClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.2
     },
     "Quartile1DecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 1.0
     },
     "Quartile1DecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 3.0
     },
     "Quartile1DecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 1.75
     },
+    "Quartile1FullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": -2.0
+    },
     "Quartile1KurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -1.6073255044800812
     },
     "Quartile1KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "Quartile1MeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.5401696428571428
     },
     "Quartile1MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "Quartile1NumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.6854678736653401
     },
     "Quartile1NumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 1.4271772823094682
     },
     "Quartile1NumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.36245927228208175
     },
+    "Quartile1OneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": -1.0
+    },
+    "Quartile1OneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": -1.0
+    },
     "Quartile1SkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.3837380662433626
     },
     "Quartile1SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "Quartile1SqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": -1.0
+    },
     "Quartile1StdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 0.7747133970184441
     },
     "Quartile1StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "Quartile2CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 4.0
     },
     "Quartile2CardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 7.5
     },
     "Quartile2CategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 1.0429703065547942
     },
     "Quartile2CategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 1.846988748800701
     },
     "Quartile2CategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.5005882075922236
     },
     "Quartile2ClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.2
     },
     "Quartile2DecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 1.5
     },
     "Quartile2DecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 3.0
     },
     "Quartile2DecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 2.0
     },
+    "Quartile2FullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": 0.0
+    },
     "Quartile2KurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -1.3493249532290488
     },
     "Quartile2KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "Quartile2MeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.5505892857142857
     },
     "Quartile2MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "Quartile2NumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.6880276426302085
     },
     "Quartile2NumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 1.468060203499046
     },
     "Quartile2NumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.3783449542841908
     },
+    "Quartile2OneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": 0.0
+    },
+    "Quartile2OneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": 0.0
+    },
     "Quartile2SkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.42456949227053975
     },
     "Quartile2SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "Quartile2SqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": -0.2899999999999999
+    },
     "Quartile2StdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 1.306626611641099
     },
     "Quartile2StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "Quartile3CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 5.0
     },
     "Quartile3CardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 8.25
     },
     "Quartile3CategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 1.2590233088047444
     },
     "Quartile3CategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 1.896449448928007
     },
     "Quartile3CategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.653394314528872
     },
     "Quartile3ClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.25
     },
     "Quartile3DecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 2.75
     },
     "Quartile3DecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 3.0
     },
     "Quartile3DecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 2.5
     },
+    "Quartile3FullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": 0.04374999999999998
+    },
     "Quartile3KurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": -1.0913244019780164
     },
     "Quartile3KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "Quartile3MeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.5610089285714286
     },
     "Quartile3MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "Quartile3NumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.6905874115950769
     },
     "Quartile3NumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 1.5089431246886238
     },
     "Quartile3NumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.39423063628629984
     },
+    "Quartile3OneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": 0.20325
+    },
+    "Quartile3OneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": 0.0
+    },
     "Quartile3SkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.46540091829771685
     },
     "Quartile3SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "Quartile3SqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": 0.0
+    },
     "Quartile3StdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 1.8385398262637536
     },
     "Quartile3StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "RandomTreeDepth1ErrRate": {
-        "compute_time": 0.006632053991779685,
+        "compute_time": 0.006247562821954489,
         "value": 0.8
     },
     "RandomTreeDepth1Kappa": {
-        "compute_time": 0.006632053991779685,
+        "compute_time": 0.006247562821954489,
         "value": -0.1356209150326797
     },
     "RandomTreeDepth2ErrRate": {
-        "compute_time": 0.006654870987404138,
+        "compute_time": 0.006273259874433279,
         "value": 0.8
     },
     "RandomTreeDepth2Kappa": {
-        "compute_time": 0.006654870987404138,
+        "compute_time": 0.006273259874433279,
         "value": -0.08187134502923976
     },
     "RandomTreeDepth3ErrRate": {
-        "compute_time": 0.006593338985112496,
+        "compute_time": 0.006270488956943154,
         "value": 0.8
     },
     "RandomTreeDepth3Kappa": {
-        "compute_time": 0.006593338985112496,
+        "compute_time": 0.006270488956943154,
         "value": -0.02631578947368418
     },
     "RatioOfCategoricalFeatures": {
-        "compute_time": 2.5093002477660775e-05,
+        "compute_time": 1.9602011889219284e-05,
         "value": 0.4
     },
     "RatioOfDistinctTokens": {
-        "compute_time": 5.389300349634141e-05,
+        "compute_time": 4.924694076180458e-05,
         "value": 0
     },
     "RatioOfFeaturesWithMissingValues": {
-        "compute_time": 0.0015022940060589463,
+        "compute_time": 0.001288380939513445,
         "value": 0.8
     },
     "RatioOfInstancesWithMissingValues": {
-        "compute_time": 0.0015022940060589463,
+        "compute_time": 0.001288380939513445,
         "value": 1.0
     },
     "RatioOfMissingValues": {
-        "compute_time": 0.0015022940060589463,
+        "compute_time": 0.001288380939513445,
         "value": 0.36
     },
     "RatioOfNumericFeatures": {
-        "compute_time": 2.5093002477660775e-05,
+        "compute_time": 1.9602011889219284e-05,
         "value": 0.6
     },
     "RatioOfTokensContainingNumericChar": {
-        "compute_time": 5.389300349634141e-05,
+        "compute_time": 4.924694076180458e-05,
         "value": 0
     },
     "SkewCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 0.0
     },
     "SkewCardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 0.0
     },
     "SkewCategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": -4.3002068602548916e-16
     },
     "SkewCategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 3.360166224435086e-15
     },
     "SkewCategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.0
     },
     "SkewClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 1.154700538379252
     },
     "SkewDecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 0.9575491625535641
     },
     "SkewDecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": -1.4999999999999996
     },
     "SkewDecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 0.6520236646847545
     },
+    "SkewFullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": 0.40452762963600386
+    },
     "SkewKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": 0.0
     },
     "SkewKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "SkewMeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.0
     },
     "SkewMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "SkewNumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": -3.2549324088873523e-14
     },
     "SkewNumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 4.065822249747896e-15
     },
     "SkewNumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.0
     },
+    "SkewOneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": 0.16988852993565123
+    },
+    "SkewOneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": -0.543491413263422
+    },
     "SkewSkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": -9.954206526050281e-16
     },
     "SkewSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "SkewSqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": -1.0338183648458683
+    },
     "SkewStdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": -2.7664266387282363e-16
     },
     "SkewStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
+    "SqrtPerceptronNIters": {
+        "compute_time": 0.009232969023287296,
+        "value": 7
+    },
+    "SqrtPerceptronWeightsSum": {
+        "compute_time": 0.009240191895514727,
+        "value": -19.741
+    },
     "StdevCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006913660035934299,
+        "compute_time": 0.0005935528315603733,
         "value": 2.8284271247461903
     },
     "StdevCardinalityOfNumericFeatures": {
-        "compute_time": 0.0006070169911254197,
+        "compute_time": 0.0005602550227195024,
         "value": 2.1213203435596424
     },
     "StdevCategoricalAttributeEntropy": {
-        "compute_time": 0.0015430200000992045,
+        "compute_time": 0.001412208890542388,
         "value": 0.6110901719466091
     },
     "StdevCategoricalJointEntropy": {
-        "compute_time": 0.0037680409877793863,
+        "compute_time": 0.0033199565950781107,
         "value": 0.1398959858490094
     },
     "StdevCategoricalMutualInformation": {
-        "compute_time": 0.0038024309906177223,
+        "compute_time": 0.0034781997092068195,
         "value": 0.4322009376864835
     },
     "StdevClassProbability": {
-        "compute_time": 0.001121197987231426,
+        "compute_time": 0.0008661109022796154,
         "value": 0.1
     },
     "StdevDecisionTreeAttribute": {
-        "compute_time": 0.004210929968394339,
+        "compute_time": 0.0039195348508656025,
         "value": 1.8929694486000912
     },
     "StdevDecisionTreeBranchLength": {
-        "compute_time": 0.004202749973046593,
+        "compute_time": 0.003919197712093592,
         "value": 0.8944271909999161
     },
     "StdevDecisionTreeLevelSize": {
-        "compute_time": 0.0042495789675740525,
+        "compute_time": 0.003951160935685039,
         "value": 1.2583057392117916
     },
+    "StdevFullPerceptronWeights": {
+        "compute_time": 0.009596982505172491,
+        "value": 1.679197509346898
+    },
     "StdevKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008750189881538972,
+        "compute_time": 0.000855493824928999,
         "value": 0.7297357573578896
     },
     "StdevKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5147979613393545e-05,
+        "compute_time": 2.2351974621415138e-05,
         "value": NaN
     },
     "StdevMeansOfNumericFeatures": {
-        "compute_time": 0.0008603659953223541,
+        "compute_time": 0.0007897447794675827,
         "value": 0.029471200487310768
     },
     "StdevMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5986984837800264e-05,
+        "compute_time": 2.299295738339424e-05,
         "value": NaN
     },
     "StdevNumericAttributeEntropy": {
-        "compute_time": 0.0053484209784073755,
+        "compute_time": 0.004672640934586525,
         "value": 0.007240119973317253
     },
     "StdevNumericJointEntropy": {
-        "compute_time": 0.007720729990978725,
+        "compute_time": 0.006831580772995949,
         "value": 0.1156343632314625
     },
     "StdevNumericMutualInformation": {
-        "compute_time": 0.007748025993350893,
+        "compute_time": 0.006897095590829849,
         "value": 0.04493149386985759
     },
+    "StdevOneHalfPerceptronWeights": {
+        "compute_time": 0.009594653733074665,
+        "value": 1.2923109615833843
+    },
+    "StdevOneTenthPerceptronWeights": {
+        "compute_time": 0.009422431932762265,
+        "value": 1.2790677408621818
+    },
     "StdevSkewnessOfNumericFeatures": {
-        "compute_time": 0.000864130983245559,
+        "compute_time": 0.0008015669882297516,
         "value": 0.11548871291733546
     },
     "StdevSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5009983801282942e-05,
+        "compute_time": 2.235989086329937e-05,
         "value": NaN
     },
+    "StdevSqrtPerceptronWeights": {
+        "compute_time": 0.009582721861079335,
+        "value": 1.1668376102655238
+    },
     "StdevStdDevOfNumericFeatures": {
-        "compute_time": 0.000890960989636369,
+        "compute_time": 0.0008303120266646147,
         "value": 1.5044777642496585
     },
     "StdevStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 2.5344983441755176e-05,
+        "compute_time": 2.260785549879074e-05,
         "value": NaN
     },
     "kNN1NErrRate": {
-        "compute_time": 0.009328829983132891,
+        "compute_time": 0.008464587619528174,
         "value": 0.8
     },
     "kNN1NKappa": {
-        "compute_time": 0.009328829983132891,
+        "compute_time": 0.008464587619528174,
         "value": -0.02631578947368407
     }
 }

--- a/tests/data/dataset_metafeatures/small_test_dataset_with_text_mf.json
+++ b/tests/data/dataset_metafeatures/small_test_dataset_with_text_mf.json
@@ -1,1102 +1,1246 @@
 {
     "CategoricalNoiseToSignalRatio": {
-        "compute_time": 0.004832903388887644,
+        "compute_time": 0.005010234657675028,
         "value": 1.0834895643494507
     },
     "ClassEntropy": {
-        "compute_time": 0.00037260702811181545,
+        "compute_time": 0.0003800089471042156,
         "value": 1.3321790402101223
     },
     "DecisionStumpErrRate": {
-        "compute_time": 0.007603144273161888,
+        "compute_time": 0.007548697292804718,
         "value": 0.7
     },
     "DecisionStumpKappa": {
-        "compute_time": 0.007603144273161888,
+        "compute_time": 0.007548697292804718,
         "value": 0.05882352941176472
     },
     "DecisionTreeHeight": {
-        "compute_time": 0.004747150000184774,
+        "compute_time": 0.004707846790552139,
         "value": 4
     },
     "DecisionTreeLeafCount": {
-        "compute_time": 0.004747150000184774,
+        "compute_time": 0.004707846790552139,
         "value": 5
     },
     "DecisionTreeNodeCount": {
-        "compute_time": 0.004747150000184774,
+        "compute_time": 0.004707846790552139,
         "value": 9
     },
     "DecisionTreeWidth": {
-        "compute_time": 0.004761883057653904,
+        "compute_time": 0.004721971927210689,
         "value": 4
     },
     "Dimensionality": {
-        "compute_time": 3.602704964578152e-05,
+        "compute_time": 3.896234557032585e-05,
         "value": 0.7
     },
     "EquivalentNumberOfCategoricalFeatures": {
-        "compute_time": 0.003834386356174946,
+        "compute_time": 0.003965348703786731,
         "value": 2.661227372130404
     },
     "EquivalentNumberOfNumericFeatures": {
-        "compute_time": 0.007453785045072436,
+        "compute_time": 0.007287570973858237,
         "value": 3.521069926069284
     },
     "FullPerceptronNIters": {
-        "compute_time": 0.010777998948469758,
+        "compute_time": 0.010440081125125289,
         "value": 7
     },
     "FullPerceptronWeightsSum": {
-        "compute_time": 0.010785212041810155,
+        "compute_time": 0.010447621112689376,
         "value": -13.024999999999999
     },
     "KurtosisCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": -2.0
     },
     "KurtosisCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": -2.0
     },
     "KurtosisCategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": -2.0
     },
     "KurtosisCategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": -2.0000000000000004
     },
     "KurtosisCategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": -2.0
     },
     "KurtosisClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": -0.6666666666666661
     },
     "KurtosisDecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": -0.8512709572742021
     },
     "KurtosisDecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 0.24999999999999867
     },
     "KurtosisDecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
+        "value": -0.9030470914127422
+    },
+    "KurtosisFullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
         "value": -0.9030470914127422
     },
     "KurtosisFullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": -0.26035017128611226
     },
     "KurtosisKurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -2.0
     },
     "KurtosisKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -2.0
     },
     "KurtosisMeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": -2.0
     },
     "KurtosisMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": -2.0
     },
     "KurtosisNumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": -2.0
     },
     "KurtosisNumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": -2.0
     },
     "KurtosisNumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": -2.0
     },
+    "KurtosisOneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": -0.6666666666666665
+    },
     "KurtosisOneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": 0.061710435495173854
     },
+    "KurtosisOneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": -1.0
+    },
     "KurtosisOneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": 0.6203674707874316
     },
     "KurtosisSkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": -1.9999999999999998
     },
     "KurtosisSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -2.0
     },
+    "KurtosisSqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -0.6666666666666665
+    },
     "KurtosisSqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": 1.4810950726966965
     },
     "KurtosisStdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": -1.9999999999999998
     },
     "KurtosisStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": -2.0
     },
     "LinearDiscriminantAnalysisErrRate": {
-        "compute_time": 0.007991681341081858,
+        "compute_time": 0.008001654176041484,
         "value": 0.7
     },
     "LinearDiscriminantAnalysisKappa": {
-        "compute_time": 0.007991681341081858,
+        "compute_time": 0.008001654176041484,
         "value": 0.042397660818713545
     },
     "MajorityClassSize": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 4
     },
     "MaxCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 6.0
     },
     "MaxCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 9.0
     },
     "MaxCategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 1.4750763110546947
     },
     "MaxCategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 1.945910149055313
     },
     "MaxCategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.8062004214655205
     },
     "MaxClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.4
     },
     "MaxDecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 5.0
     },
     "MaxDecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 3.0
     },
     "MaxDecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 4.0
     },
+    "MaxFullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": 1.0
+    },
     "MaxFullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": 4.0
     },
     "MaxKurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -0.833323850726984
     },
     "MaxKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -0.7327709457111773
     },
     "MaxMeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.5714285714285714
     },
     "MaxMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 11.444444444444445
     },
     "MaxNumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.6931471805599453
     },
     "MaxNumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 1.5498260458782016
     },
     "MaxNumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.4101163182884089
     },
+    "MaxOneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": 1.0
+    },
     "MaxOneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": 3.0
     },
+    "MaxOneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": -1.0
+    },
     "MaxOneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": 2.0
     },
     "MaxSkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.5062323443248941
     },
     "MaxSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -0.07596711654031493
     },
+    "MaxSqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -1.0
+    },
     "MaxSqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": 1.0
     },
     "MaxStdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 2.3704530408864084
     },
     "MaxStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 7.180993431738164
     },
     "MeanCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 4.0
     },
     "MeanCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 7.5
     },
     "MeanCategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 1.0429703065547942
     },
     "MeanCategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 1.846988748800701
     },
     "MeanCategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.5005882075922236
     },
     "MeanClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.25
     },
     "MeanDecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 2.25
     },
     "MeanDecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 2.6
     },
     "MeanDecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 2.25
     },
+    "MeanFullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": -1.5
+    },
     "MeanFullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": -0.3618055555555555
     },
     "MeanKurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -1.3493249532290488
     },
     "MeanKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -0.8881645688607547
     },
     "MeanMeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.5505892857142857
     },
     "MeanMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 11.372222222222224
     },
     "MeanNumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.6880276426302085
     },
     "MeanNumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 1.468060203499046
     },
     "MeanNumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.3783449542841908
     },
+    "MeanOneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": -1.25
+    },
     "MeanOneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": -0.2720833333333333
     },
+    "MeanOneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": -2.0
+    },
     "MeanOneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": -0.5516666666666666
     },
     "MeanSkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.42456949227053975
     },
     "MeanSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -0.31046540734232103
     },
+    "MeanSqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -1.25
+    },
     "MeanSqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": -0.5483611111111111
     },
     "MeanStdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 1.306626611641099
     },
     "MeanStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 6.002849186890771
     },
     "MinCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 2.0
     },
     "MinCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 6.0
     },
     "MinCategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 0.6108643020548935
     },
     "MinCategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 1.7480673485460894
     },
     "MinCategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.1949759937189266
     },
     "MinClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.2
     },
     "MinDecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 1.0
     },
     "MinDecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 1.0
     },
     "MinDecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 1.0
     },
+    "MinFullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": -5.0
+    },
     "MinFullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": -3.0
     },
     "MinKurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -1.8653260557311135
     },
     "MinKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -1.043558192010332
     },
     "MinMeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.5297499999999999
     },
     "MinMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 11.3
     },
     "MinNumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.6829081047004717
     },
     "MinNumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 1.3862943611198906
     },
     "MinNumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.3465735902799727
     },
+    "MinOneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": -2.0
+    },
     "MinOneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
+        "value": -3.0
+    },
+    "MinOneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
         "value": -3.0
     },
     "MinOneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": -4.0
     },
     "MinSkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.3429066402161854
     },
     "MinSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -0.5449636981443271
     },
+    "MinSqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -2.0
+    },
     "MinSqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": -4.159
     },
     "MinStdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 0.24280018239578932
     },
     "MinStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 4.824704942043376
     },
     "MinorityClassSize": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 2
     },
     "NaiveBayesErrRate": {
-        "compute_time": 0.008549897465854883,
+        "compute_time": 0.00845083617605269,
         "value": 0.7
     },
     "NaiveBayesKappa": {
-        "compute_time": 0.008549897465854883,
+        "compute_time": 0.00845083617605269,
         "value": -0.05555555555555547
     },
     "NumberOfCategoricalFeatures": {
-        "compute_time": 1.7587095499038696e-05,
+        "compute_time": 1.9064173102378845e-05,
         "value": 4
     },
     "NumberOfClasses": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 4
     },
     "NumberOfDistinctTokens": {
-        "compute_time": 0.003514715004712343,
+        "compute_time": 0.003771279938519001,
         "value": 18
     },
     "NumberOfFeatures": {
-        "compute_time": 1.7587095499038696e-05,
+        "compute_time": 1.9064173102378845e-05,
         "value": 7
     },
     "NumberOfFeaturesWithMissingValues": {
-        "compute_time": 0.0012503869365900755,
+        "compute_time": 0.001315239816904068,
         "value": 5
     },
     "NumberOfInstances": {
-        "compute_time": 1.7587095499038696e-05,
+        "compute_time": 1.9064173102378845e-05,
         "value": 10
     },
     "NumberOfInstancesWithMissingValues": {
-        "compute_time": 0.0012503869365900755,
+        "compute_time": 0.001315239816904068,
         "value": 10
     },
     "NumberOfMissingValues": {
-        "compute_time": 0.0012503869365900755,
+        "compute_time": 0.001315239816904068,
         "value": 19
     },
     "NumberOfNumericFeatures": {
-        "compute_time": 1.7587095499038696e-05,
+        "compute_time": 1.9064173102378845e-05,
         "value": 3
     },
     "NumberOfTokens": {
-        "compute_time": 0.003514715004712343,
+        "compute_time": 0.003771279938519001,
         "value": 45
     },
     "NumberOfTokensContainingNumericChar": {
-        "compute_time": 0.003514715004712343,
+        "compute_time": 0.003771279938519001,
         "value": 2
     },
     "NumericNoiseToSignalRatio": {
-        "compute_time": 0.011714066145941615,
+        "compute_time": 0.011662476928904653,
         "value": 0.8185194089132799
     },
     "OneHalfPerceptronNIters": {
-        "compute_time": 0.010307588148862123,
+        "compute_time": 0.010447693057358265,
         "value": 7
     },
     "OneHalfPerceptronWeightsSum": {
-        "compute_time": 0.010314709972590208,
+        "compute_time": 0.01045573502779007,
         "value": -9.794999999999998
     },
     "OneTenthPerceptronNIters": {
-        "compute_time": 0.01022178796119988,
+        "compute_time": 0.01023426279425621,
         "value": 6
     },
     "OneTenthPerceptronWeightsSum": {
-        "compute_time": 0.010228692088276148,
+        "compute_time": 0.010241986950859427,
         "value": -19.86
     },
     "PredDet": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 1.0271201550018805e-08
     },
     "PredEigen1": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 6.114621511001614
     },
     "PredEigen2": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 0.39471862161052784
     },
     "PredEigen3": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 0.2437796639097066
     },
     "PredPCA1": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 0.8662514396391524
     },
     "PredPCA2": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 0.05591933590775793
     },
     "PredPCA3": {
-        "compute_time": 0.0045937851537019014,
+        "compute_time": 0.004536337917670608,
         "value": 0.03453598631355685
     },
     "Quartile1CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 3.0
     },
     "Quartile1CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 6.75
     },
     "Quartile1CategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 0.8269173043048439
     },
     "Quartile1CategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 1.7975280486733953
     },
     "Quartile1CategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.3477821006555751
     },
     "Quartile1ClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.2
     },
     "Quartile1DecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 1.0
     },
     "Quartile1DecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 3.0
     },
     "Quartile1DecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 1.75
     },
+    "Quartile1FullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": -2.0
+    },
     "Quartile1FullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": -2.0
     },
     "Quartile1KurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -1.6073255044800812
     },
     "Quartile1KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -0.9658613804355434
     },
     "Quartile1MeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.5401696428571428
     },
     "Quartile1MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 11.336111111111112
     },
     "Quartile1NumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.6854678736653401
     },
     "Quartile1NumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 1.4271772823094682
     },
     "Quartile1NumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.36245927228208175
     },
+    "Quartile1OneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": -2.0
+    },
     "Quartile1OneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": -1.0
     },
+    "Quartile1OneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": -2.25
+    },
     "Quartile1OneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": -1.0
     },
     "Quartile1SkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.3837380662433626
     },
     "Quartile1SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -0.42771455274332404
     },
+    "Quartile1SqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -1.25
+    },
     "Quartile1SqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": -1.0
     },
     "Quartile1StdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 0.7747133970184441
     },
     "Quartile1StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 5.413777064467073
     },
     "Quartile2CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 4.0
     },
     "Quartile2CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 7.5
     },
     "Quartile2CategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 1.0429703065547942
     },
     "Quartile2CategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 1.846988748800701
     },
     "Quartile2CategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.5005882075922236
     },
     "Quartile2ClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.2
     },
     "Quartile2DecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 1.5
     },
     "Quartile2DecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 3.0
     },
     "Quartile2DecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 2.0
     },
+    "Quartile2FullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": -1.0
+    },
     "Quartile2FullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": 0.0
     },
     "Quartile2KurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -1.3493249532290488
     },
     "Quartile2KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -0.8881645688607547
     },
     "Quartile2MeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.5505892857142857
     },
     "Quartile2MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 11.372222222222224
     },
     "Quartile2NumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.6880276426302085
     },
     "Quartile2NumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 1.468060203499046
     },
     "Quartile2NumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.3783449542841908
     },
+    "Quartile2OneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": -2.0
+    },
     "Quartile2OneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": 0.0
     },
+    "Quartile2OneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": -2.0
+    },
     "Quartile2OneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": 0.0
     },
     "Quartile2SkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.42456949227053975
     },
     "Quartile2SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -0.31046540734232103
     },
+    "Quartile2SqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -1.0
+    },
     "Quartile2SqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": -0.2899999999999999
     },
     "Quartile2StdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 1.306626611641099
     },
     "Quartile2StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 6.002849186890771
     },
     "Quartile3CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 5.0
     },
     "Quartile3CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 8.25
     },
     "Quartile3CategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 1.2590233088047444
     },
     "Quartile3CategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 1.896449448928007
     },
     "Quartile3CategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.653394314528872
     },
     "Quartile3ClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.25
     },
     "Quartile3DecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 2.75
     },
     "Quartile3DecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 3.0
     },
     "Quartile3DecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 2.5
     },
+    "Quartile3FullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": -0.5
+    },
     "Quartile3FullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": 0.04374999999999998
     },
     "Quartile3KurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": -1.0913244019780164
     },
     "Quartile3KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": -0.810467757285966
     },
     "Quartile3MeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.5610089285714286
     },
     "Quartile3MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 11.408333333333335
     },
     "Quartile3NumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.6905874115950769
     },
     "Quartile3NumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 1.5089431246886238
     },
     "Quartile3NumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.39423063628629984
     },
+    "Quartile3OneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": -1.25
+    },
     "Quartile3OneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": 0.20325
     },
+    "Quartile3OneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": -1.75
+    },
     "Quartile3OneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": 0.0
     },
     "Quartile3SkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.46540091829771685
     },
     "Quartile3SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": -0.19321626194131797
     },
+    "Quartile3SqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -1.0
+    },
     "Quartile3SqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": 0.0
     },
     "Quartile3StdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 1.8385398262637536
     },
     "Quartile3StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 6.591921309314467
     },
     "RandomTreeDepth1ErrRate": {
-        "compute_time": 0.007452170364558697,
+        "compute_time": 0.007472100900486112,
         "value": 0.8
     },
     "RandomTreeDepth1Kappa": {
-        "compute_time": 0.007452170364558697,
+        "compute_time": 0.007472100900486112,
         "value": -0.1356209150326797
     },
     "RandomTreeDepth2ErrRate": {
-        "compute_time": 0.007532561430707574,
+        "compute_time": 0.007459784159436822,
         "value": 0.8
     },
     "RandomTreeDepth2Kappa": {
-        "compute_time": 0.007532561430707574,
+        "compute_time": 0.007459784159436822,
         "value": -0.08187134502923976
     },
     "RandomTreeDepth3ErrRate": {
-        "compute_time": 0.007437316235154867,
+        "compute_time": 0.007484645117074251,
         "value": 0.8
     },
     "RandomTreeDepth3Kappa": {
-        "compute_time": 0.007437316235154867,
+        "compute_time": 0.007484645117074251,
         "value": -0.02631578947368418
     },
     "RatioOfCategoricalFeatures": {
-        "compute_time": 1.7587095499038696e-05,
+        "compute_time": 1.9064173102378845e-05,
         "value": 0.5714285714285714
     },
     "RatioOfDistinctTokens": {
-        "compute_time": 0.003514715004712343,
+        "compute_time": 0.003771279938519001,
         "value": 0.4
     },
     "RatioOfFeaturesWithMissingValues": {
-        "compute_time": 0.0012503869365900755,
+        "compute_time": 0.001315239816904068,
         "value": 0.7142857142857143
     },
     "RatioOfInstancesWithMissingValues": {
-        "compute_time": 0.0012503869365900755,
+        "compute_time": 0.001315239816904068,
         "value": 1.0
     },
     "RatioOfMissingValues": {
-        "compute_time": 0.0012503869365900755,
+        "compute_time": 0.001315239816904068,
         "value": 0.2714285714285714
     },
     "RatioOfNumericFeatures": {
-        "compute_time": 1.7587095499038696e-05,
+        "compute_time": 1.9064173102378845e-05,
         "value": 0.42857142857142855
     },
     "RatioOfTokensContainingNumericChar": {
-        "compute_time": 0.003514715004712343,
+        "compute_time": 0.003771279938519001,
         "value": 0.044444444444444446
     },
     "SkewCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 0.0
     },
     "SkewCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 0.0
     },
     "SkewCategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": -4.3002068602548916e-16
     },
     "SkewCategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 3.360166224435086e-15
     },
     "SkewCategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.0
     },
     "SkewClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 1.154700538379252
     },
     "SkewDecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 0.9575491625535641
     },
     "SkewDecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": -1.4999999999999996
     },
     "SkewDecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 0.6520236646847545
     },
+    "SkewFullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": -0.6520236646847545
+    },
     "SkewFullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": 0.40452762963600386
     },
     "SkewKurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": 0.0
     },
     "SkewKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": 0.0
     },
     "SkewMeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.0
     },
     "SkewMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": -3.6910939996323705e-14
     },
     "SkewNumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": -3.2549324088873523e-14
     },
     "SkewNumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 4.065822249747896e-15
     },
     "SkewNumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.0
     },
+    "SkewOneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": 1.1547005383792515
+    },
     "SkewOneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": 0.16988852993565123
     },
+    "SkewOneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": 0.0
+    },
     "SkewOneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": -0.543491413263422
     },
     "SkewSkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": -9.954206526050281e-16
     },
     "SkewSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": 2.0179131481261978e-16
     },
+    "SkewSqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": -1.1547005383792515
+    },
     "SkewSqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": -1.0338183648458683
     },
     "SkewStdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": -2.7664266387282363e-16
     },
     "SkewStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": -1.0862625678401797e-15
     },
     "SqrtPerceptronNIters": {
-        "compute_time": 0.010263134259730577,
+        "compute_time": 0.010362454922869802,
         "value": 7
     },
     "SqrtPerceptronWeightsSum": {
-        "compute_time": 0.0102704050950706,
+        "compute_time": 0.01037030084989965,
         "value": -19.741
     },
     "StdevCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006433338858187199,
+        "compute_time": 0.000592157943174243,
         "value": 2.8284271247461903
     },
     "StdevCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005410399753600359,
+        "compute_time": 0.00063186208717525,
         "value": 2.1213203435596424
     },
     "StdevCategoricalAttributeEntropy": {
-        "compute_time": 0.0013717541005462408,
+        "compute_time": 0.0014254609122872353,
         "value": 0.6110901719466091
     },
     "StdevCategoricalJointEntropy": {
-        "compute_time": 0.0033597543369978666,
+        "compute_time": 0.0034148339182138443,
         "value": 0.1398959858490094
     },
     "StdevCategoricalMutualInformation": {
-        "compute_time": 0.003460230305790901,
+        "compute_time": 0.003583765821531415,
         "value": 0.4322009376864835
     },
     "StdevClassProbability": {
-        "compute_time": 0.0008189608342945576,
+        "compute_time": 0.0008407579734921455,
         "value": 0.1
     },
     "StdevDecisionTreeAttribute": {
-        "compute_time": 0.005146201932802796,
+        "compute_time": 0.005119402660056949,
         "value": 1.8929694486000912
     },
     "StdevDecisionTreeBranchLength": {
-        "compute_time": 0.00513794319704175,
+        "compute_time": 0.005119046662002802,
         "value": 0.8944271909999161
     },
     "StdevDecisionTreeLevelSize": {
-        "compute_time": 0.005161586217582226,
+        "compute_time": 0.005132903810590506,
         "value": 1.2583057392117916
     },
+    "StdevFullPerceptronBias": {
+        "compute_time": 0.010796632152050734,
+        "value": 2.516611478423583
+    },
     "StdevFullPerceptronWeights": {
-        "compute_time": 0.011157005093991756,
+        "compute_time": 0.010828359052538872,
         "value": 1.679197509346898
     },
     "StdevKurtosisOfNumericFeatures": {
-        "compute_time": 0.0007904439698904753,
+        "compute_time": 0.0008136329706758261,
         "value": 0.7297357573578896
     },
     "StdevKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010743183083832264,
+        "compute_time": 0.0011190955992788076,
         "value": 0.2197597693644261
     },
     "StdevMeansOfNumericFeatures": {
-        "compute_time": 0.0008562260773032904,
+        "compute_time": 0.0007946989499032497,
         "value": 0.029471200487310768
     },
     "StdevMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010563060641288757,
+        "compute_time": 0.001105946721509099,
         "value": 0.10213764617138983
     },
     "StdevNumericAttributeEntropy": {
-        "compute_time": 0.004633054137229919,
+        "compute_time": 0.004754951922222972,
         "value": 0.007240119973317253
     },
     "StdevNumericJointEntropy": {
-        "compute_time": 0.006854521110653877,
+        "compute_time": 0.006885895039886236,
         "value": 0.1156343632314625
     },
     "StdevNumericMutualInformation": {
-        "compute_time": 0.0070804632268846035,
+        "compute_time": 0.006906810216605663,
         "value": 0.04493149386985759
     },
+    "StdevOneHalfPerceptronBias": {
+        "compute_time": 0.010809883940964937,
+        "value": 1.5
+    },
     "StdevOneHalfPerceptronWeights": {
-        "compute_time": 0.01065948698669672,
+        "compute_time": 0.010813208064064384,
         "value": 1.2923109615833843
     },
+    "StdevOneTenthPerceptronBias": {
+        "compute_time": 0.010592931881546974,
+        "value": 0.816496580927726
+    },
     "StdevOneTenthPerceptronWeights": {
-        "compute_time": 0.010575975058600307,
+        "compute_time": 0.010610099881887436,
         "value": 1.2790677408621818
     },
     "StdevSkewnessOfNumericFeatures": {
-        "compute_time": 0.0007790729869157076,
+        "compute_time": 0.000840561930090189,
         "value": 0.11548871291733546
     },
     "StdevSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0010670013725757599,
+        "compute_time": 0.0011062908452004194,
         "value": 0.331630663205507
     },
+    "StdevSqrtPerceptronBias": {
+        "compute_time": 0.010720518883317709,
+        "value": 0.5
+    },
     "StdevSqrtPerceptronWeights": {
-        "compute_time": 0.010612045181915164,
+        "compute_time": 0.010726826963946223,
         "value": 1.1668376102655238
     },
     "StdevStdDevOfNumericFeatures": {
-        "compute_time": 0.0008378820493817329,
+        "compute_time": 0.0008280007168650627,
         "value": 1.5044777642496585
     },
     "StdevStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0012182251084595919,
+        "compute_time": 0.001132061704993248,
         "value": 1.666147569494993
     },
     "kNN1NErrRate": {
-        "compute_time": 0.009586704429239035,
+        "compute_time": 0.009796905098482966,
         "value": 0.8
     },
     "kNN1NKappa": {
-        "compute_time": 0.009586704429239035,
+        "compute_time": 0.009796905098482966,
         "value": -0.02631578947368407
     }
 }

--- a/tests/data/dataset_metafeatures/small_test_dataset_with_text_mf.json
+++ b/tests/data/dataset_metafeatures/small_test_dataset_with_text_mf.json
@@ -1,926 +1,1102 @@
 {
     "CategoricalNoiseToSignalRatio": {
-        "compute_time": 0.004996385017875582,
+        "compute_time": 0.004832903388887644,
         "value": 1.0834895643494507
     },
     "ClassEntropy": {
-        "compute_time": 0.00038413300353568047,
+        "compute_time": 0.00037260702811181545,
         "value": 1.3321790402101223
     },
     "DecisionStumpErrRate": {
-        "compute_time": 0.007519432998378761,
+        "compute_time": 0.007603144273161888,
         "value": 0.7
     },
     "DecisionStumpKappa": {
-        "compute_time": 0.007519432998378761,
+        "compute_time": 0.007603144273161888,
         "value": 0.05882352941176472
     },
     "DecisionTreeHeight": {
-        "compute_time": 0.004755564994411543,
+        "compute_time": 0.004747150000184774,
         "value": 4
     },
     "DecisionTreeLeafCount": {
-        "compute_time": 0.004755564994411543,
+        "compute_time": 0.004747150000184774,
         "value": 5
     },
     "DecisionTreeNodeCount": {
-        "compute_time": 0.004755564994411543,
+        "compute_time": 0.004747150000184774,
         "value": 9
     },
     "DecisionTreeWidth": {
-        "compute_time": 0.004783199998200871,
+        "compute_time": 0.004761883057653904,
         "value": 4
     },
     "Dimensionality": {
-        "compute_time": 3.920400922652334e-05,
+        "compute_time": 3.602704964578152e-05,
         "value": 0.7
     },
     "EquivalentNumberOfCategoricalFeatures": {
-        "compute_time": 0.003919733004295267,
+        "compute_time": 0.003834386356174946,
         "value": 2.661227372130404
     },
     "EquivalentNumberOfNumericFeatures": {
-        "compute_time": 0.007145581999793649,
+        "compute_time": 0.007453785045072436,
         "value": 3.521069926069284
     },
+    "FullPerceptronNIters": {
+        "compute_time": 0.010777998948469758,
+        "value": 7
+    },
+    "FullPerceptronWeightsSum": {
+        "compute_time": 0.010785212041810155,
+        "value": -13.024999999999999
+    },
     "KurtosisCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": -2.0
     },
     "KurtosisCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": -2.0
     },
     "KurtosisCategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": -2.0
     },
     "KurtosisCategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": -2.0000000000000004
     },
     "KurtosisCategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": -2.0
     },
     "KurtosisClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": -0.6666666666666661
     },
     "KurtosisDecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": -0.8512709572742021
     },
     "KurtosisDecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 0.24999999999999867
     },
     "KurtosisDecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": -0.9030470914127422
     },
+    "KurtosisFullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": -0.26035017128611226
+    },
     "KurtosisKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -2.0
     },
     "KurtosisKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -2.0
     },
     "KurtosisMeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": -2.0
     },
     "KurtosisMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": -2.0
     },
     "KurtosisNumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": -2.0
     },
     "KurtosisNumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": -2.0
     },
     "KurtosisNumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": -2.0
     },
+    "KurtosisOneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": 0.061710435495173854
+    },
+    "KurtosisOneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": 0.6203674707874316
+    },
     "KurtosisSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": -1.9999999999999998
     },
     "KurtosisSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -2.0
     },
+    "KurtosisSqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": 1.4810950726966965
+    },
     "KurtosisStdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": -1.9999999999999998
     },
     "KurtosisStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": -2.0
     },
     "LinearDiscriminantAnalysisErrRate": {
-        "compute_time": 0.008506360987666994,
+        "compute_time": 0.007991681341081858,
         "value": 0.7
     },
     "LinearDiscriminantAnalysisKappa": {
-        "compute_time": 0.008506360987666994,
+        "compute_time": 0.007991681341081858,
         "value": 0.042397660818713545
     },
     "MajorityClassSize": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 4
     },
     "MaxCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 6.0
     },
     "MaxCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 9.0
     },
     "MaxCategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 1.4750763110546947
     },
     "MaxCategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 1.945910149055313
     },
     "MaxCategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.8062004214655205
     },
     "MaxClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.4
     },
     "MaxDecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 5.0
     },
     "MaxDecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 3.0
     },
     "MaxDecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
+        "value": 4.0
+    },
+    "MaxFullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
         "value": 4.0
     },
     "MaxKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -0.833323850726984
     },
     "MaxKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -0.7327709457111773
     },
     "MaxMeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.5714285714285714
     },
     "MaxMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 11.444444444444445
     },
     "MaxNumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.6931471805599453
     },
     "MaxNumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 1.5498260458782016
     },
     "MaxNumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.4101163182884089
     },
+    "MaxOneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": 3.0
+    },
+    "MaxOneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": 2.0
+    },
     "MaxSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.5062323443248941
     },
     "MaxSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -0.07596711654031493
     },
+    "MaxSqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": 1.0
+    },
     "MaxStdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 2.3704530408864084
     },
     "MaxStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 7.180993431738164
     },
     "MeanCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 4.0
     },
     "MeanCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 7.5
     },
     "MeanCategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 1.0429703065547942
     },
     "MeanCategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 1.846988748800701
     },
     "MeanCategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.5005882075922236
     },
     "MeanClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.25
     },
     "MeanDecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 2.25
     },
     "MeanDecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 2.6
     },
     "MeanDecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 2.25
     },
+    "MeanFullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": -0.3618055555555555
+    },
     "MeanKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -1.3493249532290488
     },
     "MeanKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -0.8881645688607547
     },
     "MeanMeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.5505892857142857
     },
     "MeanMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 11.372222222222224
     },
     "MeanNumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.6880276426302085
     },
     "MeanNumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 1.468060203499046
     },
     "MeanNumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.3783449542841908
     },
+    "MeanOneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": -0.2720833333333333
+    },
+    "MeanOneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": -0.5516666666666666
+    },
     "MeanSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.42456949227053975
     },
     "MeanSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -0.31046540734232103
     },
+    "MeanSqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": -0.5483611111111111
+    },
     "MeanStdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 1.306626611641099
     },
     "MeanStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 6.002849186890771
     },
     "MinCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 2.0
     },
     "MinCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 6.0
     },
     "MinCategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 0.6108643020548935
     },
     "MinCategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 1.7480673485460894
     },
     "MinCategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.1949759937189266
     },
     "MinClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.2
     },
     "MinDecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 1.0
     },
     "MinDecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 1.0
     },
     "MinDecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 1.0
     },
+    "MinFullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": -3.0
+    },
     "MinKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -1.8653260557311135
     },
     "MinKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -1.043558192010332
     },
     "MinMeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.5297499999999999
     },
     "MinMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 11.3
     },
     "MinNumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.6829081047004717
     },
     "MinNumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 1.3862943611198906
     },
     "MinNumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.3465735902799727
     },
+    "MinOneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": -3.0
+    },
+    "MinOneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": -4.0
+    },
     "MinSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.3429066402161854
     },
     "MinSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -0.5449636981443271
     },
+    "MinSqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": -4.159
+    },
     "MinStdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 0.24280018239578932
     },
     "MinStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 4.824704942043376
     },
     "MinorityClassSize": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 2
     },
     "NaiveBayesErrRate": {
-        "compute_time": 0.008581198999308981,
+        "compute_time": 0.008549897465854883,
         "value": 0.7
     },
     "NaiveBayesKappa": {
-        "compute_time": 0.008581198999308981,
+        "compute_time": 0.008549897465854883,
         "value": -0.05555555555555547
     },
     "NumberOfCategoricalFeatures": {
-        "compute_time": 1.9059007172472775e-05,
+        "compute_time": 1.7587095499038696e-05,
         "value": 4
     },
     "NumberOfClasses": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 4
     },
     "NumberOfDistinctTokens": {
-        "compute_time": 0.003991757010226138,
+        "compute_time": 0.003514715004712343,
         "value": 18
     },
     "NumberOfFeatures": {
-        "compute_time": 1.9059007172472775e-05,
+        "compute_time": 1.7587095499038696e-05,
         "value": 7
     },
     "NumberOfFeaturesWithMissingValues": {
-        "compute_time": 0.0013372880057431757,
+        "compute_time": 0.0012503869365900755,
         "value": 5
     },
     "NumberOfInstances": {
-        "compute_time": 1.9059007172472775e-05,
+        "compute_time": 1.7587095499038696e-05,
         "value": 10
     },
     "NumberOfInstancesWithMissingValues": {
-        "compute_time": 0.0013372880057431757,
+        "compute_time": 0.0012503869365900755,
         "value": 10
     },
     "NumberOfMissingValues": {
-        "compute_time": 0.0013372880057431757,
+        "compute_time": 0.0012503869365900755,
         "value": 19
     },
     "NumberOfNumericFeatures": {
-        "compute_time": 1.9059007172472775e-05,
+        "compute_time": 1.7587095499038696e-05,
         "value": 3
     },
     "NumberOfTokens": {
-        "compute_time": 0.003991757010226138,
+        "compute_time": 0.003514715004712343,
         "value": 45
     },
     "NumberOfTokensContainingNumericChar": {
-        "compute_time": 0.003991757010226138,
+        "compute_time": 0.003514715004712343,
         "value": 2
     },
     "NumericNoiseToSignalRatio": {
-        "compute_time": 0.011622850026469678,
+        "compute_time": 0.011714066145941615,
         "value": 0.8185194089132799
     },
+    "OneHalfPerceptronNIters": {
+        "compute_time": 0.010307588148862123,
+        "value": 7
+    },
+    "OneHalfPerceptronWeightsSum": {
+        "compute_time": 0.010314709972590208,
+        "value": -9.794999999999998
+    },
+    "OneTenthPerceptronNIters": {
+        "compute_time": 0.01022178796119988,
+        "value": 6
+    },
+    "OneTenthPerceptronWeightsSum": {
+        "compute_time": 0.010228692088276148,
+        "value": -19.86
+    },
     "PredDet": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 1.0271201550018805e-08
     },
     "PredEigen1": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 6.114621511001614
     },
     "PredEigen2": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 0.39471862161052784
     },
     "PredEigen3": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 0.2437796639097066
     },
     "PredPCA1": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 0.8662514396391524
     },
     "PredPCA2": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 0.05591933590775793
     },
     "PredPCA3": {
-        "compute_time": 0.004457675007870421,
+        "compute_time": 0.0045937851537019014,
         "value": 0.03453598631355685
     },
     "Quartile1CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 3.0
     },
     "Quartile1CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 6.75
     },
     "Quartile1CategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 0.8269173043048439
     },
     "Quartile1CategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 1.7975280486733953
     },
     "Quartile1CategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.3477821006555751
     },
     "Quartile1ClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.2
     },
     "Quartile1DecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 1.0
     },
     "Quartile1DecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 3.0
     },
     "Quartile1DecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 1.75
     },
+    "Quartile1FullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": -2.0
+    },
     "Quartile1KurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -1.6073255044800812
     },
     "Quartile1KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -0.9658613804355434
     },
     "Quartile1MeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.5401696428571428
     },
     "Quartile1MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 11.336111111111112
     },
     "Quartile1NumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.6854678736653401
     },
     "Quartile1NumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 1.4271772823094682
     },
     "Quartile1NumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.36245927228208175
     },
+    "Quartile1OneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": -1.0
+    },
+    "Quartile1OneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": -1.0
+    },
     "Quartile1SkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.3837380662433626
     },
     "Quartile1SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -0.42771455274332404
     },
+    "Quartile1SqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": -1.0
+    },
     "Quartile1StdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 0.7747133970184441
     },
     "Quartile1StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 5.413777064467073
     },
     "Quartile2CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 4.0
     },
     "Quartile2CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 7.5
     },
     "Quartile2CategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 1.0429703065547942
     },
     "Quartile2CategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 1.846988748800701
     },
     "Quartile2CategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.5005882075922236
     },
     "Quartile2ClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.2
     },
     "Quartile2DecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 1.5
     },
     "Quartile2DecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 3.0
     },
     "Quartile2DecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 2.0
     },
+    "Quartile2FullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": 0.0
+    },
     "Quartile2KurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -1.3493249532290488
     },
     "Quartile2KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -0.8881645688607547
     },
     "Quartile2MeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.5505892857142857
     },
     "Quartile2MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 11.372222222222224
     },
     "Quartile2NumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.6880276426302085
     },
     "Quartile2NumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 1.468060203499046
     },
     "Quartile2NumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.3783449542841908
     },
+    "Quartile2OneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": 0.0
+    },
+    "Quartile2OneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": 0.0
+    },
     "Quartile2SkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.42456949227053975
     },
     "Quartile2SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -0.31046540734232103
     },
+    "Quartile2SqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": -0.2899999999999999
+    },
     "Quartile2StdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 1.306626611641099
     },
     "Quartile2StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 6.002849186890771
     },
     "Quartile3CardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 5.0
     },
     "Quartile3CardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 8.25
     },
     "Quartile3CategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 1.2590233088047444
     },
     "Quartile3CategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 1.896449448928007
     },
     "Quartile3CategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.653394314528872
     },
     "Quartile3ClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.25
     },
     "Quartile3DecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 2.75
     },
     "Quartile3DecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 3.0
     },
     "Quartile3DecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 2.5
     },
+    "Quartile3FullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": 0.04374999999999998
+    },
     "Quartile3KurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": -1.0913244019780164
     },
     "Quartile3KurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": -0.810467757285966
     },
     "Quartile3MeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.5610089285714286
     },
     "Quartile3MeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 11.408333333333335
     },
     "Quartile3NumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.6905874115950769
     },
     "Quartile3NumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 1.5089431246886238
     },
     "Quartile3NumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.39423063628629984
     },
+    "Quartile3OneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": 0.20325
+    },
+    "Quartile3OneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": 0.0
+    },
     "Quartile3SkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.46540091829771685
     },
     "Quartile3SkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": -0.19321626194131797
     },
+    "Quartile3SqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": 0.0
+    },
     "Quartile3StdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 1.8385398262637536
     },
     "Quartile3StdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 6.591921309314467
     },
     "RandomTreeDepth1ErrRate": {
-        "compute_time": 0.007847974004107527,
+        "compute_time": 0.007452170364558697,
         "value": 0.8
     },
     "RandomTreeDepth1Kappa": {
-        "compute_time": 0.007847974004107527,
+        "compute_time": 0.007452170364558697,
         "value": -0.1356209150326797
     },
     "RandomTreeDepth2ErrRate": {
-        "compute_time": 0.00788460198964458,
+        "compute_time": 0.007532561430707574,
         "value": 0.8
     },
     "RandomTreeDepth2Kappa": {
-        "compute_time": 0.00788460198964458,
+        "compute_time": 0.007532561430707574,
         "value": -0.08187134502923976
     },
     "RandomTreeDepth3ErrRate": {
-        "compute_time": 0.008033875987166539,
+        "compute_time": 0.007437316235154867,
         "value": 0.8
     },
     "RandomTreeDepth3Kappa": {
-        "compute_time": 0.008033875987166539,
+        "compute_time": 0.007437316235154867,
         "value": -0.02631578947368418
     },
     "RatioOfCategoricalFeatures": {
-        "compute_time": 1.9059007172472775e-05,
+        "compute_time": 1.7587095499038696e-05,
         "value": 0.5714285714285714
     },
     "RatioOfDistinctTokens": {
-        "compute_time": 0.003991757010226138,
+        "compute_time": 0.003514715004712343,
         "value": 0.4
     },
     "RatioOfFeaturesWithMissingValues": {
-        "compute_time": 0.0013372880057431757,
+        "compute_time": 0.0012503869365900755,
         "value": 0.7142857142857143
     },
     "RatioOfInstancesWithMissingValues": {
-        "compute_time": 0.0013372880057431757,
+        "compute_time": 0.0012503869365900755,
         "value": 1.0
     },
     "RatioOfMissingValues": {
-        "compute_time": 0.0013372880057431757,
+        "compute_time": 0.0012503869365900755,
         "value": 0.2714285714285714
     },
     "RatioOfNumericFeatures": {
-        "compute_time": 1.9059007172472775e-05,
+        "compute_time": 1.7587095499038696e-05,
         "value": 0.42857142857142855
     },
     "RatioOfTokensContainingNumericChar": {
-        "compute_time": 0.003991757010226138,
+        "compute_time": 0.003514715004712343,
         "value": 0.044444444444444446
     },
     "SkewCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 0.0
     },
     "SkewCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 0.0
     },
     "SkewCategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": -4.3002068602548916e-16
     },
     "SkewCategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 3.360166224435086e-15
     },
     "SkewCategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.0
     },
     "SkewClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 1.154700538379252
     },
     "SkewDecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 0.9575491625535641
     },
     "SkewDecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": -1.4999999999999996
     },
     "SkewDecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 0.6520236646847545
     },
+    "SkewFullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": 0.40452762963600386
+    },
     "SkewKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": 0.0
     },
     "SkewKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": 0.0
     },
     "SkewMeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.0
     },
     "SkewMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": -3.6910939996323705e-14
     },
     "SkewNumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": -3.2549324088873523e-14
     },
     "SkewNumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 4.065822249747896e-15
     },
     "SkewNumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.0
     },
+    "SkewOneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": 0.16988852993565123
+    },
+    "SkewOneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": -0.543491413263422
+    },
     "SkewSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": -9.954206526050281e-16
     },
     "SkewSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": 2.0179131481261978e-16
     },
+    "SkewSqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": -1.0338183648458683
+    },
     "SkewStdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": -2.7664266387282363e-16
     },
     "SkewStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": -1.0862625678401797e-15
     },
+    "SqrtPerceptronNIters": {
+        "compute_time": 0.010263134259730577,
+        "value": 7
+    },
+    "SqrtPerceptronWeightsSum": {
+        "compute_time": 0.0102704050950706,
+        "value": -19.741
+    },
     "StdevCardinalityOfCategoricalFeatures": {
-        "compute_time": 0.0006040810112608597,
+        "compute_time": 0.0006433338858187199,
         "value": 2.8284271247461903
     },
     "StdevCardinalityOfNumericFeatures": {
-        "compute_time": 0.0005782410007668659,
+        "compute_time": 0.0005410399753600359,
         "value": 2.1213203435596424
     },
     "StdevCategoricalAttributeEntropy": {
-        "compute_time": 0.0014615540130762383,
+        "compute_time": 0.0013717541005462408,
         "value": 0.6110901719466091
     },
     "StdevCategoricalJointEntropy": {
-        "compute_time": 0.003323216995340772,
+        "compute_time": 0.0033597543369978666,
         "value": 0.1398959858490094
     },
     "StdevCategoricalMutualInformation": {
-        "compute_time": 0.003533922994392924,
+        "compute_time": 0.003460230305790901,
         "value": 0.4322009376864835
     },
     "StdevClassProbability": {
-        "compute_time": 0.0008413559990003705,
+        "compute_time": 0.0008189608342945576,
         "value": 0.1
     },
     "StdevDecisionTreeAttribute": {
-        "compute_time": 0.005235812001046725,
+        "compute_time": 0.005146201932802796,
         "value": 1.8929694486000912
     },
     "StdevDecisionTreeBranchLength": {
-        "compute_time": 0.005243924009846523,
+        "compute_time": 0.00513794319704175,
         "value": 0.8944271909999161
     },
     "StdevDecisionTreeLevelSize": {
-        "compute_time": 0.0053174979984760284,
+        "compute_time": 0.005161586217582226,
         "value": 1.2583057392117916
     },
+    "StdevFullPerceptronWeights": {
+        "compute_time": 0.011157005093991756,
+        "value": 1.679197509346898
+    },
     "StdevKurtosisOfNumericFeatures": {
-        "compute_time": 0.0008311910060001537,
+        "compute_time": 0.0007904439698904753,
         "value": 0.7297357573578896
     },
     "StdevKurtosisOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0013846859947079793,
+        "compute_time": 0.0010743183083832264,
         "value": 0.2197597693644261
     },
     "StdevMeansOfNumericFeatures": {
-        "compute_time": 0.0008160220022546127,
+        "compute_time": 0.0008562260773032904,
         "value": 0.029471200487310768
     },
     "StdevMeansOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014370889985002577,
+        "compute_time": 0.0010563060641288757,
         "value": 0.10213764617138983
     },
     "StdevNumericAttributeEntropy": {
-        "compute_time": 0.004861487017478794,
+        "compute_time": 0.004633054137229919,
         "value": 0.007240119973317253
     },
     "StdevNumericJointEntropy": {
-        "compute_time": 0.00662510801339522,
+        "compute_time": 0.006854521110653877,
         "value": 0.1156343632314625
     },
     "StdevNumericMutualInformation": {
-        "compute_time": 0.006760709002264775,
+        "compute_time": 0.0070804632268846035,
         "value": 0.04493149386985759
     },
+    "StdevOneHalfPerceptronWeights": {
+        "compute_time": 0.01065948698669672,
+        "value": 1.2923109615833843
+    },
+    "StdevOneTenthPerceptronWeights": {
+        "compute_time": 0.010575975058600307,
+        "value": 1.2790677408621818
+    },
     "StdevSkewnessOfNumericFeatures": {
-        "compute_time": 0.0008531590137863532,
+        "compute_time": 0.0007790729869157076,
         "value": 0.11548871291733546
     },
     "StdevSkewnessOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014534349902532995,
+        "compute_time": 0.0010670013725757599,
         "value": 0.331630663205507
     },
+    "StdevSqrtPerceptronWeights": {
+        "compute_time": 0.010612045181915164,
+        "value": 1.1668376102655238
+    },
     "StdevStdDevOfNumericFeatures": {
-        "compute_time": 0.0008458100055577233,
+        "compute_time": 0.0008378820493817329,
         "value": 1.5044777642496585
     },
     "StdevStdDevOfStringLengthOfTextFeatures": {
-        "compute_time": 0.0014100179832894355,
+        "compute_time": 0.0012182251084595919,
         "value": 1.666147569494993
     },
     "kNN1NErrRate": {
-        "compute_time": 0.009689243990578689,
+        "compute_time": 0.009586704429239035,
         "value": 0.8
     },
     "kNN1NKappa": {
-        "compute_time": 0.009689243990578689,
+        "compute_time": 0.009586704429239035,
         "value": -0.02631578947368407
     }
 }


### PR DESCRIPTION
Add the following metafeatures (for a perceptron induced on the full dataset, 1/10 of the data, 1/2 of the data, and sqrt(n) of the data):
- Perceptron Weights (avg, std, min, etc weight)
- Perceptron Biases (avg, std, min, etc bias)
- Sum of Perceptron Weights
- Number of Iterations (to convergance)
