### PR TITLE
Add Code Coverage and Develop/Master Badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ python:
 
 install:
   - pip install -r requirements.txt
+  - pip install codecov
   - python setup.py install
   - rm -r metalearn
 
 script:
-  - nosetests -s -v
+  - nosetests -s -v --with-coverage --cover-package=metalearn
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Build Status](https://api.travis-ci.org/byu-dml/metalearn.png)](https://travis-ci.org/byu-dml/metalearn)
+| **Develop**                                                                                                                                  | **Master**                                                                                                                                 |
+|----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| [![Build Status](https://travis-ci.org/byu-dml/metalearn.svg?branch=develop)](https://travis-ci.org/byu-dml/metalearn)                       | [![Build Status](https://travis-ci.org/byu-dml/metalearn.svg?branch=master)](https://travis-ci.org/byu-dml/metalearn)                      |
+| [![codecov](https://codecov.io/gh/byu-dml/metalearn/branch/develop/graph/badge.svg)](https://codecov.io/gh/byu-dml/metalearn/branch/develop) | [![codecov](https://codecov.io/gh/byu-dml/metalearn/branch/master/graph/badge.svg)](https://codecov.io/gh/byu-dml/metalearn/branch/master) |
 
 # Metalearn
 


### PR DESCRIPTION
Adds badges to the README for code coverage and Travis CI build for both develop and master branches. When the Travis CI badges are clicked on, they just go to the general landing page for `metalearn` CI. When the codecov badges are clicked, they go to the code coverage reports for their respective branches. Travis CI doesn't seem to have URLs for individual branches that you can link to.