### PR TITLE
Use metafeature groups for filtering

### DIFF
--- a/metalearn/metafeatures/base.py
+++ b/metalearn/metafeatures/base.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 import inspect
-from typing import List, Callable, Dict, Union, Optional
+from typing import Any, Callable, Sequence, Mapping, Optional, Union
 
 from metalearn.metafeatures.constants import ProblemType, MetafeatureGroup
 
@@ -22,8 +22,7 @@ class ResourceComputer:
     """
 
     def __init__(
-        self, computer: Callable, returns: List[str],
-        argmap: Optional[Dict[str,Union[str,int,float]]] = None
+        self, computer: Callable, returns: Sequence[str], argmap: Optional[Mapping[str,Any]] = None
     ) -> None:
         argspec = inspect.getfullargspec(computer)
         # TODO: If needed, add support for `computer` functions that use these types of arguments.
@@ -34,7 +33,7 @@ class ResourceComputer:
             raise ValueError('`computer` must use only positional arguments with no default values')
 
         self.computer: Callable = computer
-        self.returns: List[str] = returns
+        self.returns: Sequence[str] = returns
         self.argmap = {arg_name: arg_name for arg_name in argspec.args}
 
         if argmap is not None:
@@ -77,8 +76,8 @@ class MetafeatureComputer(ResourceComputer):
     """
 
     def __init__(
-        self, computer: Callable, returns: List[str], problem_type: ProblemType, groups: List[MetafeatureGroup],
-        argmap: Optional[Dict[str,Union[str,int,float]]] = None
+        self, computer: Callable, returns: Sequence[str], problem_type: ProblemType, groups: Sequence[MetafeatureGroup],
+        argmap: Optional[Mapping[str,Any]] = None
     ) -> None:
         # TODO: Add support for passing a string to `returns`, not just a list?
         super().__init__(computer, returns, argmap)

--- a/metalearn/metafeatures/base.py
+++ b/metalearn/metafeatures/base.py
@@ -93,6 +93,8 @@ class collectordict(Mapping):
     For simplicity, all values must be set manually, not in __init__.
     """
 
+    # TODO: define __str__ method
+
     dict_cls = dict
 
     def __init__(self):

--- a/metalearn/metafeatures/base.py
+++ b/metalearn/metafeatures/base.py
@@ -1,6 +1,6 @@
-from collections.abc import Mapping
+from collections import abc
 import inspect
-from typing import Any, Callable, Sequence, Mapping, Optional, Union
+import typing
 
 from metalearn.metafeatures.constants import ProblemType, MetafeatureGroup
 
@@ -22,7 +22,7 @@ class ResourceComputer:
     """
 
     def __init__(
-        self, computer: Callable, returns: Sequence[str], argmap: Optional[Mapping[str,Any]] = None
+        self, computer: typing.Callable, returns: typing.Sequence[str], argmap: typing.Mapping[str, typing.Any] = None
     ) -> None:
         argspec = inspect.getfullargspec(computer)
         # TODO: If needed, add support for `computer` functions that use these types of arguments.
@@ -32,8 +32,8 @@ class ResourceComputer:
         ):
             raise ValueError('`computer` must use only positional arguments with no default values')
 
-        self.computer: Callable = computer
-        self.returns: Sequence[str] = returns
+        self.computer: typing.Callable = computer
+        self.returns: typing.Sequence[str] = returns
         self.argmap = {arg_name: arg_name for arg_name in argspec.args}
 
         if argmap is not None:
@@ -76,8 +76,8 @@ class MetafeatureComputer(ResourceComputer):
     """
 
     def __init__(
-        self, computer: Callable, returns: Sequence[str], problem_type: ProblemType, groups: Sequence[MetafeatureGroup],
-        argmap: Optional[Mapping[str,Any]] = None
+        self, computer: typing.Callable, returns: typing.Sequence[str], problem_type: ProblemType,
+        groups: typing.Sequence[MetafeatureGroup], argmap: typing.Mapping[str, typing.Any] = None
     ) -> None:
         # TODO: Add support for passing a string to `returns`, not just a list?
         super().__init__(computer, returns, argmap)
@@ -85,7 +85,7 @@ class MetafeatureComputer(ResourceComputer):
         self.problem_type = problem_type
 
 
-class collectordict(Mapping):
+class collectordict(abc.Mapping):
     """
     A partially mutable mapping in which keys can be set at most one time.
     A LookupError is raised if a key is set more than once. Keys cannot be deleted.
@@ -113,7 +113,7 @@ class collectordict(Mapping):
             raise LookupError(f'{key} already exists')
         self._dict[key] = value
 
-    def update(self, mapping: Mapping):
+    def update(self, mapping: typing.Mapping):
         for key, value in mapping.items():
             self[key] = value
 

--- a/metalearn/metafeatures/decision_tree_metafeatures.py
+++ b/metalearn/metafeatures/decision_tree_metafeatures.py
@@ -103,7 +103,10 @@ get_decision_tree_level_sizes = MetafeatureComputer(
         "MaxDecisionTreeLevelSize"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.MODEL_BASED],
+    [
+        MetafeatureGroup.MODEL_BASED,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "tree": "TraversedDecisionTree"
     }
@@ -127,7 +130,10 @@ get_decision_tree_branch_lengths = MetafeatureComputer(
         "MaxDecisionTreeBranchLength"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.MODEL_BASED],
+    [
+        MetafeatureGroup.MODEL_BASED,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "tree": "TraversedDecisionTree"
     }
@@ -151,7 +157,10 @@ get_decision_tree_attributes = MetafeatureComputer(
         "MaxDecisionTreeAttribute"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.MODEL_BASED],
+    [
+        MetafeatureGroup.MODEL_BASED,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "tree": "DecisionTree"
     }
@@ -169,7 +178,10 @@ get_decision_tree_general_info = MetafeatureComputer(
         "DecisionTreeHeight",
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.MODEL_BASED],
+    [
+        MetafeatureGroup.MODEL_BASED,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "tree": "DecisionTree"
     }
@@ -183,7 +195,10 @@ get_decision_tree_width = MetafeatureComputer(
     get_decision_tree_width,
     ["DecisionTreeWidth"],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.MODEL_BASED],
+    [
+        MetafeatureGroup.MODEL_BASED,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "tree": "TraversedDecisionTree"
     }

--- a/metalearn/metafeatures/information_theoretic_metafeatures.py
+++ b/metalearn/metafeatures/information_theoretic_metafeatures.py
@@ -17,7 +17,10 @@ get_class_entropy = MetafeatureComputer(
     get_class_entropy,
     ["ClassEntropy"],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "Y_sample": "YSample"
     }
@@ -87,7 +90,10 @@ get_categorical_joint_entropy = MetafeatureComputer(
         "MaxCategoricalJointEntropy"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "feature_class_array": "NoNaNCategoricalFeaturesAndClass"
     }
@@ -107,7 +113,10 @@ get_numeric_joint_entropy = MetafeatureComputer(
         "MaxNumericJointEntropy"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "feature_class_array": "NoNaNBinnedNumericFeaturesAndClass"
     }
@@ -132,7 +141,10 @@ get_categorical_mutual_information = MetafeatureComputer(
         "MaxCategoricalMutualInformation"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "feature_class_array": "NoNaNCategoricalFeaturesAndClass"
     }
@@ -152,7 +164,10 @@ get_numeric_mutual_information = MetafeatureComputer(
         "MaxNumericMutualInformation"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "feature_class_array": "NoNaNBinnedNumericFeaturesAndClass"
     }
@@ -170,7 +185,10 @@ get_equivalent_number_categorical_features = MetafeatureComputer(
     get_equivalent_number_features,
     ["EquivalentNumberOfCategoricalFeatures"],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "class_entropy": "ClassEntropy",
         "mutual_information": "MeanCategoricalMutualInformation"
@@ -181,7 +199,10 @@ get_equivalent_number_numeric_features = MetafeatureComputer(
     get_equivalent_number_features,
     ["EquivalentNumberOfNumericFeatures"],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "class_entropy": "ClassEntropy",
         "mutual_information": "MeanNumericMutualInformation"
@@ -200,7 +221,10 @@ get_categorical_noise_signal_ratio = MetafeatureComputer(
     get_noise_signal_ratio,
     ["CategoricalNoiseToSignalRatio"],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "attribute_entropy": "MeanCategoricalAttributeEntropy",
         "mutual_information": "MeanCategoricalMutualInformation"
@@ -211,7 +235,10 @@ get_numeric_noise_signal_ratio = MetafeatureComputer(
     get_noise_signal_ratio,
     ["NumericNoiseToSignalRatio"],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.INFO_THEORETIC],
+    [
+        MetafeatureGroup.INFO_THEORETIC,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "attribute_entropy": "MeanNumericAttributeEntropy",
         "mutual_information": "MeanNumericMutualInformation"

--- a/metalearn/metafeatures/landmarking_metafeatures.py
+++ b/metalearn/metafeatures/landmarking_metafeatures.py
@@ -51,7 +51,10 @@ get_naive_bayes = MetafeatureComputer(
         "NaiveBayesKappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample"
@@ -72,7 +75,10 @@ get_knn_1 = MetafeatureComputer(
         "kNN1NKappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample"
@@ -95,7 +101,10 @@ get_decision_stump = MetafeatureComputer(
         "DecisionStumpKappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample",
@@ -120,7 +129,10 @@ get_random_tree_depth_1 = MetafeatureComputer(
         "RandomTreeDepth1Kappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample",
@@ -136,7 +148,10 @@ get_random_tree_depth_2 = MetafeatureComputer(
         "RandomTreeDepth2Kappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample",
@@ -152,7 +167,10 @@ get_random_tree_depth_3 = MetafeatureComputer(
         "RandomTreeDepth3Kappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample",
@@ -175,7 +193,10 @@ get_lda = MetafeatureComputer(
         "LinearDiscriminantAnalysisKappa"
     ],
     ProblemType.CLASSIFICATION,
-    [MetafeatureGroup.LANDMARKING],
+    [
+        MetafeatureGroup.LANDMARKING,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ],
     {
         "X": "XPreprocessed",
         "Y": "YSample"

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -58,7 +58,7 @@ class Metafeatures(object):
     IDS: List[str] = [mf_id for mfs_info in _mfs_info for mf_id in mfs_info.keys()]
 
     @classmethod
-    def list_metafeatures(cls, group: consts.MetafeatureGroup='all'):
+    def list_metafeatures(cls, group: consts.MetafeatureGroup=consts.MetafeatureGroup.ALL):
         """
         Returns a list of metafeatures computable by the Metafeatures class.
         """
@@ -71,7 +71,7 @@ class Metafeatures(object):
         if group not in [i.value for i in consts.MetafeatureGroup]:
             raise ValueError(f"Unknown group {group}")
 
-        if group == consts.MetafeatureGroup.ALL.value:
+        if group == consts.MetafeatureGroup.ALL:
             return copy.deepcopy(cls.IDS)
         else:
             return list(
@@ -323,7 +323,7 @@ class Metafeatures(object):
             metafeature_ids is not None):
             # when computing landmarking metafeatures, there must be at least
             # n_folds instances of each class of Y
-            landmarking_mfs = self.list_metafeatures(group="landmarking")
+            landmarking_mfs = self.list_metafeatures(group=consts.MetafeatureGroup.LANDMARKING)
             if len(list(filter(
                 lambda mf_id: mf_id in landmarking_mfs,metafeature_ids
             ))):

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -1,6 +1,6 @@
-import time
 from copy import deepcopy
-from typing import Dict, List
+import time
+import typing
 
 import numpy as np
 import pandas as pd
@@ -51,10 +51,10 @@ class Metafeatures(object):
     for mf_info in _mfs_info:
         _resources_info.update(mf_info)
 
-    IDS: List[str] = [mf_id for mfs_info in _mfs_info for mf_id in mfs_info.keys()]
+    IDS: typing.Sequence[str] = [mf_id for mfs_info in _mfs_info for mf_id in mfs_info.keys()]
 
     @classmethod
-    def list_metafeatures(cls, group: str = 'all') -> List[str]:
+    def list_metafeatures(cls, group: str = 'all') -> typing.Sequence[str]:
         """
         Lists the ids of computable metafeatures.
 
@@ -83,55 +83,63 @@ class Metafeatures(object):
         else:
             return [id_ for id_ in cls.IDS if consts.MetafeatureGroup(group) in cls._resources_info[id_].groups]
 
+    # TODO: make most args kw only
     def compute(
-        self, X: pd.DataFrame, Y: pd.Series = None,
-        column_types: Dict[str, str] = None, metafeature_ids: List[str] = None,
-        exclude: List[str] = None, sample_shape = None, seed = None, n_folds: int = 2,
-        verbose: bool = False, timeout = None, groups: List[str] = None,
-        exclude_groups: List[str] = None, return_times: bool = False
+        self, X: pd.DataFrame, Y: pd.Series = None, column_types: typing.Mapping[str, str] = None,
+        metafeature_ids: typing.Sequence[str] = None, exclude: typing.Sequence[str] = None, sample_shape = None,
+        seed: int = None, n_folds: int = 2, verbose: bool = False, timeout = None, return_times: bool = False,
+        groups: typing.Sequence[str] = None, exclude_groups: typing.Sequence[str] = None
     ) -> dict:
         """
         Parameters
         ----------
-        X: pandas.DataFrame, the dataset features
-        Y: pandas.Series, the dataset targets
-        column_types: Dict[str, str], dict from column name to column type as
-            "NUMERIC" or "CATEGORICAL" or "TEXT", must include Y column
-        metafeature_ids: list, the metafeatures to compute. Default of None
-            indicates to compute all metafeatures.
-        exclude: list, default None. The metafeatures to be excluded from
-            computation. Must be None if metafeature_ids is not None.
-            **TODO** This parameter will be renamed in a future version. See
-            https://github.com/byu-dml/metalearn/issues/210.
-        sample_shape: tuple, the shape of X after sampling (X,Y) uniformly.
-            Default is (None, None), indicate not to sample rows or columns.
-        seed: int, the seed used to generate pseudo-random numbers. when None
-            is given, a seed will be generated pseudo-randomly. this can be
-            used for reproducibility of metafeatures. a generated seed can be
-            accessed through the 'seed' property, after calling this method.
-        n_folds: int, the number of cross validation folds used by the
+        X: pandas.DataFrame
+            The dataset features
+        Y: pandas.Series
+            The dataset targets
+        column_types: Mapping[str, str]
+            Maps column names to semantic types. Valid typs include "NUMERIC", "CATEGORICAL", and "TEXT".
+            Must include Y.name if Y is not None.
+        metafeature_ids: Sequence[str]
+            The metafeatures to compute. None indicates to compute all metafeatures. Mutually exclusive with `exclude`.
+        exclude: Sequence[str]
+            All metafeatures except those listed in `exclude` will be computed.
+            Mutually exclustive with `metafeature_ids`.
+            **TODO** This parameter will be renamed in a future version.
+            See https://github.com/byu-dml/metalearn/issues/210.
+        sample_shape: tuple
+            The shape of X after sampling (X,Y) uniformly. Default is (None, None), indicate not to sample rows or
+            columns.
+        seed: int
+            The seed used to generate pseudo-random numbers. When None is given, a seed will be generated
+            pseudo-randomly. This can be used for reproducibility of metafeatures. A generated seed can be accessed
+            through the 'seed' property, after calling this method.
+        n_folds: int
+            the number of cross validation folds used by the
             landmarking metafeatures. also affects the sample_shape validation
-        verbose: bool, default False. When True, prints the ID of each
+        verbose: bool
+            When True, prints the ID of each
             metafeature right before it is about to be computed.
-        timeout: float, default None. If timeout is None, compute_metafeatures
+        timeout: float
+            If timeout is None, compute_metafeatures
             will be run to completion. Otherwise, execution will halt after
             approximately timeout seconds. Any metafeatures that have not been
             computed will be labeled 'TIMEOUT'.
-        groups: list, default None. Must consist only of values enumerated in
-            constants.MetafeatureGroup. The metafeature groups to be computed.
-            Values listed in metafeature_ids or exclude take precedence over
-            groups and exclude_groups (e.g., if 'landmarking' is in the list
-            exclude_groups but 'NaiveBayesErrRate' is in metafeature_ids,
-            NaiveBayesErrRate will be computed while all other landmarking
-            metafeatures will be excluded). This parameter is mutually exclusive
-            with exclude_groups, i.e., groups must be None if exclude_groups is
-            not None. If both are non-null, a ValueError will be raised.
-        exclude_groups: list, default None. Must consist only of values enumerated in
-            constants.MetafeatureGroup. The metafeature groups to exclude from
-            computation. Must be None if groups is not None.
-        return_times: bool, default False. When true, includes compute times for
-            each metafeature. **Note** compute times are overestimated.
+        return_times: bool
+            When true, includes compute times for each metafeature. **Note** compute times are overestimated.
             See https://github.com/byu-dml/metalearn/issues/205.
+        groups: list
+            The metafeature groups to be computed. Must consist only of values
+            enumerated in constants.MetafeatureGroup. Values listed in
+            metafeature_ids or exclude take precedence over groups (e.g., if
+            'landmarking' is in the list exclude_groups but 'NaiveBayesErrRate'
+            is in metafeature_ids, NaiveBayesErrRate will be computed while all
+            other landmarking metafeatures will be excluded). At least one of
+            groups and exclude_groups must be None.
+        exclude_groups: list
+            The metafeature groups to exclude from computation. Must consist
+            only of values enumerated in constants.MetafeatureGroup. At least
+            one of groups and exclude_groups must be None.
 
         Returns
         -------
@@ -334,10 +342,10 @@ class Metafeatures(object):
             raise ValueError(f"`n_folds` must be an integer, not {n_folds}")
         if n_folds < 2:
             raise ValueError(f"`n_folds` must be >= 2, but was {n_folds}")
-        if (Y is not None and 
-            column_types is not None and 
-            column_types[Y.name] != consts.NUMERIC and 
-            metafeature_ids is not None):
+        if (
+            Y is not None and column_types is not None and column_types[Y.name] != consts.NUMERIC and
+            metafeature_ids is not None
+        ):
             # when computing landmarking metafeatures, there must be at least
             # n_folds instances of each class of Y
             landmarking_mfs = self.list_metafeatures(group=consts.MetafeatureGroup.LANDMARKING.value)

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -58,7 +58,7 @@ class Metafeatures(object):
     IDS: List[str] = [mf_id for mfs_info in _mfs_info for mf_id in mfs_info.keys()]
 
     @classmethod
-    def list_metafeatures(cls, group: consts.MetafeatureGroup=consts.MetafeatureGroup.ALL):
+    def list_metafeatures(cls, group: consts.MetafeatureGroup=consts.MetafeatureGroup.ALL.value):
         """
         Returns a list of metafeatures computable by the Metafeatures class.
         """
@@ -71,7 +71,7 @@ class Metafeatures(object):
         if group not in [i.value for i in consts.MetafeatureGroup]:
             raise ValueError(f"Unknown group {group}")
 
-        if group == consts.MetafeatureGroup.ALL:
+        if group == consts.MetafeatureGroup.ALL.value:
             return copy.deepcopy(cls.IDS)
         else:
             return list(
@@ -325,7 +325,7 @@ class Metafeatures(object):
             metafeature_ids is not None):
             # when computing landmarking metafeatures, there must be at least
             # n_folds instances of each class of Y
-            landmarking_mfs = self.list_metafeatures(group=consts.MetafeatureGroup.LANDMARKING)
+            landmarking_mfs = self.list_metafeatures(group=consts.MetafeatureGroup.LANDMARKING.value)
             if len(list(filter(
                 lambda mf_id: mf_id in landmarking_mfs,metafeature_ids
             ))):

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -78,12 +78,10 @@ class Metafeatures(object):
         if group not in valid_metafeature_group_values:
             raise ValueError('Invalid group: {}. Must be one of {}'.format(group, valid_metafeature_group_values))
 
-        group = consts.MetafeatureGroup(group)
-
-        if group == consts.MetafeatureGroup.ALL:
+        if group == consts.MetafeatureGroup.ALL.value:
             return [id_ for id_ in cls.IDS]
         else:
-            return [id_ for id_ in cls.IDS if group in cls._resources_info[id_].groups]
+            return [id_ for id_ in cls.IDS if consts.MetafeatureGroup(group) in cls._resources_info[id_].groups]
 
     def compute(
         self, X: pd.DataFrame, Y: pd.Series = None,

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -92,6 +92,8 @@ class Metafeatures(object):
             indicates to compute all metafeatures.
         exclude: list, default None. The metafeatures to be excluded from
             computation. Must be None if metafeature_ids is not None.
+            **TODO** This parameter will be renamed in a future version. See
+            https://github.com/byu-dml/metalearn/issues/210.
         sample_shape: tuple, the shape of X after sampling (X,Y) uniformly.
             Default is (None, None), indicate not to sample rows or columns.
         seed: int, the seed used to generate pseudo-random numbers. when None

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -68,7 +68,7 @@ class Metafeatures(object):
             raise ValueError(f"Unknown group {group}")
 
         if group == consts.MetafeatureGroup.ALL:
-            return copy.deepcopy(cls.IDS)
+            return deepcopy(cls.IDS)
         else:
             return list(
                 mf_id for mf_id in cls.IDS if group in [g for g in cls._resources_info[mf_id].groups]

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -116,7 +116,9 @@ class Metafeatures(object):
             groups and exclude_groups (e.g., if 'landmarking' is in the list
             exclude_groups but 'NaiveBayesErrRate' is in metafeature_ids,
             NaiveBayesErrRate will be computed while all other landmarking
-            metafeatures will be excluded).
+            metafeatures will be excluded). This parameter is mutually exclusive
+            with exclude_groups, i.e., groups must be None if exclude_groups is
+            not None. If both are non-null, a ValueError will be raised.
         exclude_groups: list, default None. Must consist only of values enumerated in
             constants.MetafeatureGroup. The metafeature groups to exclude from
             computation. Must be None if groups is not None.

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -151,7 +151,7 @@ class Metafeatures(object):
         start_time = time.time()
         self._validate_compute_arguments(
             X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-            n_folds, verbose, groups, exclude_groups, return_times
+            n_folds, verbose, return_times, groups, exclude_groups
         )
         if timeout is None:
             def check_time():
@@ -172,7 +172,7 @@ class Metafeatures(object):
             seed = np.random.randint(np.iinfo(np.int32).max)
         self._validate_compute_arguments(
             X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-            n_folds, verbose, groups, exclude_groups, return_times
+            n_folds, verbose, return_times, groups, exclude_groups
         )
 
         self._init_resources(
@@ -234,7 +234,7 @@ class Metafeatures(object):
 
     def _validate_compute_arguments(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         for f in [
             self._validate_X, self._validate_Y, self._validate_column_types,
@@ -244,12 +244,12 @@ class Metafeatures(object):
         ]:
             f(
                 X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-                n_folds, verbose, groups, exclude_groups, return_times
+                n_folds, verbose, return_times, groups, exclude_groups
             )
 
     def _validate_X(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not isinstance(X, pd.DataFrame):
             raise TypeError('X must be of type pandas.DataFrame')
@@ -258,7 +258,7 @@ class Metafeatures(object):
 
     def _validate_Y(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not isinstance(Y, pd.Series) and not Y is None:
             raise TypeError('Y must be of type pandas.Series')
@@ -267,7 +267,7 @@ class Metafeatures(object):
 
     def _validate_column_types(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not column_types is None:
             invalid_column_types = {}
@@ -291,7 +291,7 @@ class Metafeatures(object):
 
     def _validate_metafeature_ids(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         ids = None
         if metafeature_ids is not None and exclude is not None:
@@ -314,7 +314,7 @@ class Metafeatures(object):
 
     def _validate_sample_shape(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not sample_shape is None:
             if not type(sample_shape) in [tuple, list]:
@@ -336,7 +336,7 @@ class Metafeatures(object):
 
     def _validate_n_folds(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not dtype_is_numeric(type(n_folds)) or (n_folds != int(n_folds)):
             raise ValueError(f"`n_folds` must be an integer, not {n_folds}")
@@ -363,14 +363,14 @@ class Metafeatures(object):
 
     def _validate_verbose(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not type(verbose) is bool:
             raise ValueError("`verbose` must be of type bool.")
 
     def _validate_groups(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if groups is not None and exclude_groups is not None:
             raise ValueError('groups and exclude_groups cannot both be set')
@@ -387,7 +387,7 @@ class Metafeatures(object):
 
     def _validate_return_times(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
-        n_folds, verbose, groups, exclude_groups, return_times
+        n_folds, verbose, return_times, groups, exclude_groups
     ):
         if not type(return_times) is bool:
             raise ValueError("`return_times` must be of type bool.")

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -114,7 +114,7 @@ class Metafeatures(object):
             constants.MetafeatureGroup. The metafeature groups to be computed.
             Values listed in metafeature_ids or exclude take precedence over
             groups and exclude_groups (e.g., if 'landmarking' is in the list
-            exclude_group but 'NaiveBayesErrRate' is in metafeature_ids,
+            exclude_groups but 'NaiveBayesErrRate' is in metafeature_ids,
             NaiveBayesErrRate will be computed while all other landmarking
             metafeatures will be excluded).
         exclude_groups: list, default None. Must consist only of values enumerated in

--- a/metalearn/metafeatures/metafeatures.py
+++ b/metalearn/metafeatures/metafeatures.py
@@ -355,24 +355,18 @@ class Metafeatures(object):
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,
         n_folds, verbose, groups, exclude_groups, return_times
     ):
-        group_labels = None
         if groups is not None and exclude_groups is not None:
-            raise ValueError("groups and exclude_groups cannot both be non-null")
-        elif groups is not None:
-            group_labels = groups
-            list_label = 'requested'
-        elif exclude_groups is not None:
-            group_labels = exclude_groups
-            list_label = 'excluded'
-        if group_labels is not None:
-            invalid_group_labels = [
-                gr for gr in group_labels if gr not in [i for i in consts.MetafeatureGroup]
-            ]
-            if len(invalid_group_labels) > 0:
-                raise ValueError(
-                    'One or more {} metafeature groups are not valid: {}'.
-                    format(list_label, invalid_group_labels)
-                )
+            raise ValueError('groups and exclude_groups cannot both be set')
+
+        if groups is not None:
+            invalid_groups = [group for group in groups if group not in consts.MetafeatureGroup]
+            if invalid_groups:
+                raise ValueError('groups contains invalid values: {}'.format(invalid_groups))
+
+        if exclude_groups is not None:
+            invalid_groups = [group for group in exclude_groups if group not in consts.MetafeatureGroup]
+            if invalid_groups:
+                raise ValueError('exclude_groups contains invalid values: {}'.format(invalid_groups))
 
     def _validate_return_times(
         self, X, Y, column_types, metafeature_ids, exclude, sample_shape, seed,

--- a/metalearn/metafeatures/simple_metafeatures.py
+++ b/metalearn/metafeatures/simple_metafeatures.py
@@ -104,7 +104,10 @@ get_class_stats = MetafeatureComputer(
         "MajorityClassSize"
     ],
     problem_type=ProblemType.CLASSIFICATION,
-    groups=[MetafeatureGroup.SIMPLE]
+    groups=[
+        MetafeatureGroup.SIMPLE,
+        MetafeatureGroup.TARGET_DEPENDENT
+    ]
 )
 
 

--- a/tests/test_metafeatures.py
+++ b/tests/test_metafeatures.py
@@ -213,7 +213,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_mfs = dataset["known_metafeatures"]
             target_dependent_metafeatures = Metafeatures.list_metafeatures(
-                consts.MetafeatureGroup.TARGET_DEPENDENT.value
+                consts.MetafeatureGroup.TARGET_DEPENDENT
             )
             for mf_name in target_dependent_metafeatures:
                 known_mfs[mf_name] = {
@@ -247,7 +247,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_mfs = dataset["known_metafeatures"]
             target_dependent_metafeatures = Metafeatures.list_metafeatures(
-                consts.MetafeatureGroup.TARGET_DEPENDENT.value
+                consts.MetafeatureGroup.TARGET_DEPENDENT
             )
             for mf_name in target_dependent_metafeatures:
                 known_mfs[mf_name] = {
@@ -318,7 +318,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
         test_name = inspect.stack()[0][3]
         for dataset_filename, dataset in self.datasets.items():
             groups = random.sample(
-                [i.value for i in consts.MetafeatureGroup],
+                [i for i in consts.MetafeatureGroup],
                 SUBSET_LENGTH
             )
             computed_mfs = Metafeatures().compute(
@@ -350,7 +350,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
         test_name = inspect.stack()[0][3]
         for dataset_filename, dataset in self.datasets.items():
             groups = random.sample(
-                [i.value for i in consts.MetafeatureGroup],
+                [i for i in consts.MetafeatureGroup],
                 SUBSET_LENGTH
             )
             computed_mfs = Metafeatures().compute(

--- a/tests/test_metafeatures.py
+++ b/tests/test_metafeatures.py
@@ -617,7 +617,7 @@ class MetafeaturesTestCase(unittest.TestCase):
         self.assertEqual(str(cm.exception), expected_exception_string)
 
     def test_request_and_exclude_metafeature_groups(self):
-        expected_exception_string_1 = "groups and exclude_groups cannot both be non-null"
+        expected_exception_string_1 = "groups and exclude_groups cannot both be set"
 
         with self.assertRaises(ValueError) as cm:
             Metafeatures().compute(X=self.dummy_features, Y=self.dummy_target,
@@ -625,13 +625,13 @@ class MetafeaturesTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), expected_exception_string_1)
 
-        expected_exception_string_2 = "One or more requested metafeature groups are not valid: ['foobar']"
+        expected_exception_string_2 = "groups contains invalid values: ['foobar']"
 
         with self.assertRaises(ValueError) as cm:
             Metafeatures().compute(X=self.dummy_features, Y=self.dummy_target,
                                    groups=['foobar'])
 
-        expected_exception_string_3 = "One or more excluded metafeature groups are not valid: ['foobar']"
+        expected_exception_string_3 = "exclude_groups contains invalid values: ['foobar']"
 
         with self.assertRaises(ValueError) as cm:
             Metafeatures().compute(X=self.dummy_features, Y=self.dummy_target,

--- a/tests/test_metafeatures.py
+++ b/tests/test_metafeatures.py
@@ -213,7 +213,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_mfs = dataset["known_metafeatures"]
             target_dependent_metafeatures = Metafeatures.list_metafeatures(
-                "target_dependent"
+                consts.MetafeatureGroup.TARGET_DEPENDENT.value
             )
             for mf_name in target_dependent_metafeatures:
                 known_mfs[mf_name] = {
@@ -247,7 +247,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_mfs = dataset["known_metafeatures"]
             target_dependent_metafeatures = Metafeatures.list_metafeatures(
-                "target_dependent"
+                consts.MetafeatureGroup.TARGET_DEPENDENT.value
             )
             for mf_name in target_dependent_metafeatures:
                 known_mfs[mf_name] = {

--- a/tests/test_metafeatures.py
+++ b/tests/test_metafeatures.py
@@ -241,7 +241,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             column_types[dataset["Y"].name] = consts.NUMERIC
             computed_mfs = metafeatures.compute(
                 X=dataset["X"], Y=pd.Series(np.random.rand(dataset["Y"].shape[0]),
-                name=dataset["Y"].name), seed=CORRECTNESS_SEED, 
+                name=dataset["Y"].name), seed=CORRECTNESS_SEED,
                 column_types=column_types
             )
             known_mfs = dataset["known_metafeatures"]
@@ -323,8 +323,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_metafeatures = dataset["known_metafeatures"]
             required_checks = [
-                (self._check_correctness,
-                 [computed_mfs, known_metafeatures, dataset_filename])
+                (self._check_correctness, [computed_mfs, known_metafeatures, dataset_filename])
             ]
             test_failures.update(self._perform_checks(required_checks))
 
@@ -339,31 +338,20 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
         test_failures = {}
         test_name = inspect.stack()[0][3]
         for dataset_filename, dataset in self.datasets.items():
-            groups = random.sample(
-                [i.value for i in consts.MetafeatureGroup],
-                SUBSET_LENGTH
-            )
+            groups = random.sample([group.value for group in consts.MetafeatureGroup], SUBSET_LENGTH)
             computed_mfs = Metafeatures().compute(
-                X=dataset["X"], Y=dataset["Y"], seed=CORRECTNESS_SEED,
+                X=dataset["X"], Y=dataset["Y"], column_types=dataset["column_types"], seed=CORRECTNESS_SEED,
                 exclude_groups=groups,
-                column_types=dataset["column_types"]
             )
             known_metafeatures = dataset["known_metafeatures"]
             required_checks = [
-                (self._check_correctness,
-                 [computed_mfs, known_metafeatures, dataset_filename])
+                (self._check_correctness, [computed_mfs, known_metafeatures, dataset_filename])
             ]
             test_failures.update(self._perform_checks(required_checks))
 
-            metafeature_ids = list(set(
-                [mf for sublist in [
-                    Metafeatures.list_metafeatures(g) for g in groups
-                ] for mf in sublist]
-            ))
-
+            metafeature_ids = set(mf_id for group in groups for mf_id in Metafeatures.list_metafeatures(group))
             if any(mf_id in computed_mfs.keys() for mf_id in metafeature_ids):
-                self.assertTrue(False, "Metafeatures computed an excluded metafeature")
-
+                self.fail('Metafeatures computed an excluded metafeature')
         self._report_test_failures(test_failures, test_name)
 
     def test_compute_effects_on_dataset(self):
@@ -445,9 +433,9 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
                 )
 
     def test_soft_timeout(self):
-        """Tests Metafeatures().compute() with timeout set"""   
-        test_name = inspect.stack()[0][3]   
-        test_failures = {} 
+        """Tests Metafeatures().compute() with timeout set"""
+        test_name = inspect.stack()[0][3]
+        test_failures = {}
         for dataset_filename, dataset in self.datasets.items():
             metafeatures = Metafeatures()
 

--- a/tests/test_metafeatures.py
+++ b/tests/test_metafeatures.py
@@ -312,6 +312,70 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
 
         self._report_test_failures(test_failures, test_name)
 
+    def test_request_metafeature_groups(self):
+        SUBSET_LENGTH = 3
+        test_failures = {}
+        test_name = inspect.stack()[0][3]
+        for dataset_filename, dataset in self.datasets.items():
+            groups = random.sample(
+                [i.value for i in consts.MetafeatureGroup],
+                SUBSET_LENGTH
+            )
+            computed_mfs = Metafeatures().compute(
+                X=dataset["X"], Y=dataset["Y"], seed=CORRECTNESS_SEED,
+                groups=groups,
+                column_types=dataset["column_types"]
+            )
+            known_metafeatures = dataset["known_metafeatures"]
+            required_checks = [
+                (self._check_correctness,
+                 [computed_mfs, known_metafeatures, dataset_filename])
+            ]
+            test_failures.update(self._perform_checks(required_checks))
+
+            metafeature_ids = list(set(
+                [mf for sublist in [
+                    Metafeatures().list_metafeatures(g) for g in groups
+                ] for mf in sublist]
+            ))
+            self.assertEqual(
+                metafeature_ids.sort(), list(computed_mfs.keys()).sort(),
+                "Compute did not return requested metafeatures"
+            )
+        self._report_test_failures(test_failures, test_name)
+
+    def test_exclude_metafeature_groups(self):
+        SUBSET_LENGTH = 3
+        test_failures = {}
+        test_name = inspect.stack()[0][3]
+        for dataset_filename, dataset in self.datasets.items():
+            groups = random.sample(
+                [i.value for i in consts.MetafeatureGroup],
+                SUBSET_LENGTH
+            )
+            computed_mfs = Metafeatures().compute(
+                X=dataset["X"], Y=dataset["Y"], seed=CORRECTNESS_SEED,
+                exclude_groups=groups,
+                column_types=dataset["column_types"]
+            )
+            known_metafeatures = dataset["known_metafeatures"]
+            required_checks = [
+                (self._check_correctness,
+                 [computed_mfs, known_metafeatures, dataset_filename])
+            ]
+            test_failures.update(self._perform_checks(required_checks))
+
+            metafeature_ids = list(set(
+                [mf for sublist in [
+                    Metafeatures().list_metafeatures(g) for g in groups
+                ] for mf in sublist]
+            ))
+
+            if any(mf_id in computed_mfs.keys() for mf_id in metafeature_ids):
+                self.assertTrue(False, "Metafeatures computed an excluded metafeature")
+
+        self._report_test_failures(test_failures, test_name)
+
     def test_compute_effects_on_dataset(self):
         """
         Tests whether computing metafeatures has any side effects on the input
@@ -551,6 +615,29 @@ class MetafeaturesTestCase(unittest.TestCase):
                                    metafeature_ids=[], exclude=[])
 
         self.assertEqual(str(cm.exception), expected_exception_string)
+
+    def test_request_and_exclude_metafeature_groups(self):
+        expected_exception_string_1 = "groups and exclude_groups cannot both be non-null"
+
+        with self.assertRaises(ValueError) as cm:
+            Metafeatures().compute(X=self.dummy_features, Y=self.dummy_target,
+                                   groups=[], exclude_groups=[])
+
+        self.assertEqual(str(cm.exception), expected_exception_string_1)
+
+        expected_exception_string_2 = "One or more requested metafeature groups are not valid: ['foobar']"
+
+        with self.assertRaises(ValueError) as cm:
+            Metafeatures().compute(X=self.dummy_features, Y=self.dummy_target,
+                                   groups=['foobar'])
+
+        expected_exception_string_3 = "One or more excluded metafeature groups are not valid: ['foobar']"
+
+        with self.assertRaises(ValueError) as cm:
+            Metafeatures().compute(X=self.dummy_features, Y=self.dummy_target,
+                                   exclude_groups=['foobar'])
+
+        self.assertEqual(str(cm.exception), expected_exception_string_3)
 
     def test_column_type_input(self):
         column_types = {col: consts.NUMERIC for col in self.dummy_features.columns}

--- a/tests/test_metafeatures.py
+++ b/tests/test_metafeatures.py
@@ -213,7 +213,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_mfs = dataset["known_metafeatures"]
             target_dependent_metafeatures = Metafeatures.list_metafeatures(
-                consts.MetafeatureGroup.TARGET_DEPENDENT
+                consts.MetafeatureGroup.TARGET_DEPENDENT.value
             )
             for mf_name in target_dependent_metafeatures:
                 known_mfs[mf_name] = {
@@ -247,7 +247,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
             )
             known_mfs = dataset["known_metafeatures"]
             target_dependent_metafeatures = Metafeatures.list_metafeatures(
-                consts.MetafeatureGroup.TARGET_DEPENDENT
+                consts.MetafeatureGroup.TARGET_DEPENDENT.value
             )
             for mf_name in target_dependent_metafeatures:
                 known_mfs[mf_name] = {
@@ -335,7 +335,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
 
             metafeature_ids = list(set(
                 [mf for sublist in [
-                    Metafeatures().list_metafeatures(g) for g in groups
+                    Metafeatures().list_metafeatures(g.value) for g in groups
                 ] for mf in sublist]
             ))
             self.assertEqual(
@@ -367,7 +367,7 @@ class MetafeaturesWithDataTestCase(unittest.TestCase):
 
             metafeature_ids = list(set(
                 [mf for sublist in [
-                    Metafeatures().list_metafeatures(g) for g in groups
+                    Metafeatures().list_metafeatures(g.value) for g in groups
                 ] for mf in sublist]
             ))
 


### PR DESCRIPTION
Resolves #195. In PR #192 the enum `MetafeatureGroup` was introduced for tagging metafeatures. This PR tags target-dependent metafeatures as such and leverages the new groups for filtering in `Metafeatures.list_metafeatures()` and `Metafeatures.compute()`, with appropriate new unit tests included.