### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include metalearn/metafeatures/metafeatures_schema.json
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     url = 'https://github.com/byu-dml/metalearn',
     download_url = 'https://github.com/byu-dml/metalearn/archive/{}.tar.gz'.format(__version__),
     keywords = ['metalearning', 'machine learning', 'metalearn'],
+    license='MIT',
     install_requires = [
         'numpy<=1.18.2',
         'scikit-learn<=0.22.2.post1',


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.